### PR TITLE
feat(effects): add volume slide + fix noise channel UGE export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ test.ps1
 
 # generate GitHub Issues
 .github/ISSUES
+t.cmd

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -95,6 +95,34 @@ Instrument semantics
 - Pattern operations: `transposePattern` utility correctly handles notes with inline effects by extracting the note, transposing it, and reconstructing the token with effects intact (e.g., `E3<port:8>` → `E2<port:8>`).
 - Testing: Comprehensive demo in `songs/effects/port_effect_demo.bax` validates WebAudio playback, PCM rendering, UGE export, and transpose operations.
 
+## Noise Channel Note Mapping (UGE Export)
+
+**Status**: ✅ Implemented (2026-01-25)
+
+The Game Boy noise channel doesn't use traditional musical pitches—notes control the LFSR shift and divisor parameters. Early versions applied an automatic +36 semitone transpose during UGE export, mapping C2→index 36, but this caused notes to be clamped at the maximum index (72), appearing as "???" in hUGETracker.
+
+**Current behavior (v0.1.0+)**:
+- **1:1 mapping**: Notes export directly to hUGETracker indices with NO automatic transpose
+  - C2 → index 0 (C-3 in hUGETracker notation)
+  - C5 → index 24 (C-5, mid-range percussion)
+  - C6 → index 36 (C-6)
+  - C7 → index 48 (C-7, bright percussion)  
+  - C9 → index 72 (C-9, maximum)
+- **Recommendation**: Use C5-C7 for typical percussion sounds (snares, hi-hats)
+- **Override**: Add `uge_transpose=N` to instrument definition for custom offsets
+- **Default note value**: When instrument name appears without explicit note (e.g., `hihat * 8`), defaults to MIDI note 60 (C7) → index 24
+
+**Implementation**:
+- `packages/engine/src/export/ugeWriter.ts` lines 918-928: Removed automatic transpose logic
+- `packages/engine/src/export/ugeWriter.ts` line 1070: Changed default note from 36 to 60
+- `docs/uge-export-guide.md`: Updated "Noise Channel Note Mapping" section
+- `songs/percussion_demo.bax`: Added header comments with mapping examples
+
+**Files modified**:
+- `ugeWriter.ts`: Removed +36 transpose, updated default note value
+- `uge-export-guide.md`: Complete rewrite of noise mapping section
+- `percussion_demo.bax`: Documentation with C2-C9 mapping table
+
 ## Vibrato (`vib`) Implementation
 
 - Syntax: `C5<vib:depth,rate,waveform,duration>` where:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A concise feature summary:
 - Exports: validated ISM JSON, 4-track MIDI, hUGETracker v6, and WAV via CLI
 - CLI features: headless playback, offline WAV rendering, per-channel export, sample-rate/duration controls
 - Extensible toolchain: UGE import, plugin-friendly architecture, per-channel mute/solo, and tests
+- **Noise channel**: Direct 1:1 note mapping to hUGETracker (C2→index 0, C7→index 48), no automatic transpose
 
 ## Language examples
 

--- a/apps/web-ui/index.html
+++ b/apps/web-ui/index.html
@@ -21,6 +21,13 @@
         </div>
 
         <textarea id="src" placeholder="Paste .bax source here..." style="width:100%; height:320px; font-family:monospace; font-size:13px; resize:vertical"></textarea>
+        <div id="warnings" style="display:none; margin-top:8px; padding:8px; background:#fff3cd; border:1px solid #ffc107; border-radius:4px; max-height:120px; overflow-y:auto;">
+          <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:4px;">
+            <strong style="color:#856404;">⚠️ Warnings</strong>
+            <button id="clearWarnings" style="background:none; border:none; cursor:pointer; font-size:18px; line-height:1; padding:0 4px;" title="Clear warnings">×</button>
+          </div>
+          <div id="warningsList" style="font-family:monospace; font-size:12px; color:#856404;"></div>
+        </div>
         <div class="controls" style="margin-top:8px">
           <button id="play">Play</button>
           <button id="stop">Stop</button>

--- a/docs/uge-export-guide.md
+++ b/docs/uge-export-guide.md
@@ -208,6 +208,42 @@ effect arpMajor7 = arp:4,7,11  # Warning: only 4,7 exported to UGE
 pat chords = C4<arpMinor>:4 F4<arpMajor>:4 G4<arpMinor>:4
 ```
 
+### Noise Channel Note Mapping
+
+The Game Boy noise channel doesn't use traditional musical pitches. Instead, notes control the noise generator's shift and divisor parameters. **BeatBax exports noise channel notes directly to hUGETracker** with NO automatic transpose applied.
+
+- **Direct 1:1 mapping:** Notes are exported exactly as written in BeatBax:
+  - `C2` in BeatBax → exports as index **0** (C-3 in hUGETracker = lowest noise)
+  - `C5` in BeatBax → exports as index **24** (C-5 in hUGETracker = mid-range percussion)
+  - `C7` in BeatBax → exports as index **48** (C-7 in hUGETracker = bright percussion)
+  - `C9` in BeatBax → exports as index **72** (C-9 in hUGETracker = maximum, highest)
+  - Notes above `C9` are clamped to index **72**
+  - Notes below `C2` are transposed up by octaves to fit in valid range
+- **Write in target range:** For typical percussion sounds, use **C5-C7** (indices 24-48), which map to common snare/hi-hat sounds in hUGETracker
+- **Custom transpose if needed:** Add `uge_transpose=N` to your noise instrument to shift all notes:
+  ```
+  inst kick type=noise env=gb:12,down,1 uge_transpose=12  # Shift up 1 octave
+  ```
+- **Round-trip behavior:** When importing UGE files, noise notes remain at their hUGETracker index values (same as exported)
+
+Example:
+```bax
+chip gameboy
+bpm 120
+
+# Write percussion notes in the exact range you want in hUGETracker
+inst kick  type=noise env=gb:12,down,1 width=15  # Use C2-C3 (deep sounds)
+inst snare type=noise env=gb:10,down,2 width=7   # Use C5-C6 (mid-range)
+inst hat   type=noise env=gb:8,down,1 width=7    # Use C7-C8 (bright sounds)
+
+# Direct mapping: C2→0, C5→24, C6→36, C7→48, C8→60
+pat drums = C2 . C5 . C6 C7 C2 C8
+
+channel 4 => inst kick pat drums
+```
+
+**Important:** The 1:1 mapping applies during **UGE export**. BeatBax's internal playback uses these as relative brightness controls for the noise generator. MIDI export maps noise notes to GM percussion (e.g., C5→Snare, C7→Hi-hat).
+
 ### Vibrato (vib) mapping
 
 When exporting BeatBax songs for Game Boy, the BeatBax `vib` effect is conservatively mapped into hUGETracker's compact `4xy` vibrato effect so the exported `.uge` behaves sensibly in tracker/driver toolchains.

--- a/packages/engine/src/chips/gameboy/noise.ts
+++ b/packages/engine/src/chips/gameboy/noise.ts
@@ -2,7 +2,7 @@
 import { parseEnvelope } from './pulse.js';
 import { GB_CLOCK } from './periodTables.js';
 
-export function playNoise(ctx: BaseAudioContext | any, start: number, dur: number, inst: any, scheduler?: any, destination?: AudioNode) {
+export function playNoise(ctx: BaseAudioContext | any, start: number, dur: number, inst: any, scheduler?: any, destination?: AudioNode, skipEnvelope?: boolean) {
   const sr = ctx.sampleRate;
   const len = Math.ceil(Math.min(1, dur + 0.05) * sr);
   const buf = ctx.createBuffer(1, len, sr);
@@ -48,7 +48,10 @@ export function playNoise(ctx: BaseAudioContext | any, start: number, dur: numbe
 
   const env = parseEnvelope(inst && inst.env);
   const g = gain.gain;
-  if (env && env.mode === 'gb') {
+  // Skip envelope automation if skipEnvelope flag is set (e.g., when volume effects are present)
+  if (skipEnvelope) {
+    g.setValueAtTime(0.8, start);
+  } else if (env && env.mode === 'gb') {
     const initialVol = (env.initial ?? 15) / 15;
     const stepPeriod = (env.period ?? 1) * (65536 / GB_CLOCK);
     if (env.period && env.period > 0) {

--- a/packages/engine/src/chips/gameboy/pulse.ts
+++ b/packages/engine/src/chips/gameboy/pulse.ts
@@ -31,24 +31,32 @@ export function parseEnvelope(envStr: any) {
     if (isGbFormat) {
       const initialRaw = obj.initial ?? obj.level ?? obj.value;
       const initial = Math.max(0, Math.min(15, Number.isFinite(Number(initialRaw)) ? Number(initialRaw) : 15));
-      const dirStr = (obj.direction ?? obj.dir ?? 'down');
-      const direction = String(dirStr).toLowerCase() === 'up' ? 'up' : 'down';
+      const dirStr = String(obj.direction ?? obj.dir ?? 'down').toLowerCase();
+      let direction: 'up' | 'down' | 'flat' = 'down';
+      if (dirStr === 'up') direction = 'up';
+      else if (dirStr === 'flat') direction = 'flat';
+      else direction = 'down';
       const periodRaw = obj.period ?? obj.step ?? obj.periodRaw ?? 1;
-      const period = Math.max(0, Math.min(7, Number.isFinite(Number(periodRaw)) ? Number(periodRaw) : 1));
+      const period = (direction === 'flat') ? 0 : Math.max(0, Math.min(7, Number.isFinite(Number(periodRaw)) ? Number(periodRaw) : 1));
       return { mode: 'gb', initial, direction, period };
     }
     return obj;
   }
   const s = String(envStr).trim();
-  const gbPrefixed = s.match(/^gb:\s*(\d{1,2})\s*,\s*(up|down)(?:\s*,\s*(\d+))?$/i);
+  const gbPrefixed = s.match(/^gb:\s*(\d{1,2})\s*,\s*(up|down|flat)(?:\s*,\s*(\d+))?$/i);
   const parts = s.split(',').map(p => p.trim()).filter(Boolean);
-  const gbThree = parts.length >= 3 && /^\d{1,2}$/.test(parts[0]) && /^(up|down)$/i.test(parts[1]);
-  const gb = gbPrefixed || (gbThree ? parts : null);
+  const gbThree = parts.length >= 3 && /^\d{1,2}$/.test(parts[0]) && /^(up|down|flat)$/i.test(parts[1]);
+  const gbTwo = parts.length >= 2 && /^\d{1,2}$/.test(parts[0]) && /^(up|down|flat)$/i.test(parts[1]);
+  const gb = gbPrefixed || (gbThree ? parts : (gbTwo ? parts : null));
   if (gb) {
     const initial = Math.max(0, Math.min(15, parseInt((gbPrefixed ? gb[1] : parts[0]) as any, 10)));
-    const direction = (gbPrefixed ? gb[2] : parts[1]).toLowerCase() === 'up' ? 'up' : 'down';
+    const directionStr = (gbPrefixed ? gb[2] : parts[1]).toLowerCase();
+    let direction: 'up' | 'down' | 'flat' = 'down';
+    if (directionStr === 'up') direction = 'up';
+    else if (directionStr === 'flat') direction = 'flat';
+    else direction = 'down';
     const periodRaw = gbPrefixed ? gb[3] : parts[2];
-    const period = Math.max(0, Math.min(7, Number.isFinite(Number(periodRaw)) ? Number(periodRaw) : 1));
+    const period = (direction === 'flat') ? 0 : Math.max(0, Math.min(7, Number.isFinite(Number(periodRaw)) ? Number(periodRaw) : 1));
     return { mode: 'gb', initial, direction, period };
   }
 

--- a/packages/engine/src/effects/types.ts
+++ b/packages/engine/src/effects/types.ts
@@ -1,6 +1,6 @@
 export type EffectParams = Array<string | number>;
 
-export type EffectHandler = (ctx: any, nodes: any[], params: EffectParams, start: number, dur: number, chId?: number, tickSeconds?: number) => void;
+export type EffectHandler = (ctx: any, nodes: any[], params: EffectParams, start: number, dur: number, chId?: number, tickSeconds?: number, inst?: any) => void;
 
 export interface EffectRegistry {
   register: (name: string, handler: EffectHandler) => void;

--- a/packages/engine/src/parser/ast.ts
+++ b/packages/engine/src/parser/ast.ts
@@ -92,6 +92,7 @@ export interface ChannelNode {
   inst?: string;
   pat?: string | string[];
   speed?: number;
+  loc?: SourceLocation;
 }
 
 export interface PlayNode {

--- a/packages/engine/src/parser/peggy/generated/parser.ts
+++ b/packages/engine/src/parser/peggy/generated/parser.ts
@@ -4441,6 +4441,9 @@ function peg$parse(input, options) {
     s4 = peg$currPos;
     peg$silentFails++;
     s5 = peg$parseNewline();
+    if (s5 === peg$FAILED) {
+      s5 = peg$parseComment();
+    }
     peg$silentFails--;
     if (s5 === peg$FAILED) {
       s4 = undefined;
@@ -4473,6 +4476,9 @@ function peg$parse(input, options) {
       s4 = peg$currPos;
       peg$silentFails++;
       s5 = peg$parseNewline();
+      if (s5 === peg$FAILED) {
+        s5 = peg$parseComment();
+      }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
         s4 = undefined;

--- a/packages/engine/src/parser/peggy/grammar.peggy
+++ b/packages/engine/src/parser/peggy/grammar.peggy
@@ -371,7 +371,7 @@ IdentifierWithArgs
 // -----------------------------
 
 RestOfLine
-  = s:$( (!Newline .)* ) { return s.trim(); }
+  = s:$( (!(Newline / Comment) .)* ) { return s.trim(); }
 
 Identifier
   = $([A-Za-z_][A-Za-z0-9_\-]*)

--- a/packages/engine/src/parser/peggy/index.ts
+++ b/packages/engine/src/parser/peggy/index.ts
@@ -340,9 +340,9 @@ const expandPatternSpec = (nameSpec: string, rhsRaw?: string, rhsTokens?: string
   }
 };
 
-const parseChannelRhs = (id: number, rhs: string, pats: Record<string, string[]>): ChannelNode & { seqSpecTokens?: string[] } => {
+const parseChannelRhs = (id: number, rhs: string, pats: Record<string, string[]>, loc?: SourceLocation): ChannelNode & { seqSpecTokens?: string[] } => {
   const tokens = rhs.split(/\s+/);
-  const ch: { id: number; inst?: string; pat?: string | string[]; speed?: number; seqSpecTokens?: string[] } = { id };
+  const ch: { id: number; inst?: string; pat?: string | string[]; speed?: number; seqSpecTokens?: string[]; loc?: SourceLocation } = { id, loc };
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
     if (t === 'inst' && tokens[i + 1]) {
@@ -524,7 +524,7 @@ export function parseWithPeggy(source: string): AST {
         break;
       }
       case 'ChannelStmt': {
-        channels.push(parseChannelRhs(stmt.channel, stmt.rhs.trim(), pats));
+        channels.push(parseChannelRhs(stmt.channel, stmt.rhs.trim(), pats, stmt.loc));
         break;
       }
       case 'PlayStmt': {

--- a/packages/engine/src/song/resolver.ts
+++ b/packages/engine/src/song/resolver.ts
@@ -301,7 +301,7 @@ export function resolveSong(ast: AST, opts?: { filename?: string; onWarn?: (d: {
         const repeat = mRep ? parseInt(mRep[2], 10) : 1;
         const itemRef = mRep ? mRep[1].trim() : item;
         for (let r = 0; r < repeat; r++) {
-          const toks = expandRefToTokens(itemRef, expandedSeqs, pats, ast.effects as any);
+          const toks = expandRefToTokens(itemRef, expandedSeqs, pats, ast.effects as any, ch.loc);
           outTokens.push(...toks);
         }
       }

--- a/packages/engine/tests/parser.inline-comments.test.ts
+++ b/packages/engine/tests/parser.inline-comments.test.ts
@@ -1,0 +1,65 @@
+import { parseWithPeggy } from '../src/parser/peggy';
+import { resolveSong } from '../src/song/resolver';
+import type { NoteEvent } from '../src/song/songModel';
+
+describe('Inline comments', () => {
+  it('should ignore inline comments in channel assignments', () => {
+    const code = `
+      chip gameboy
+      bpm 120
+      
+      inst test type=pulse1 duty=50 env=10,flat
+      
+      pat a = C4 E4
+      pat b = G4 B4
+      pat c = C5 E5
+      
+      seq seq1 = a
+      seq seq2 = b
+      seq seq3 = c
+      
+      # This channel should only play seq1, not seq2 and seq3
+      channel 1 => inst test seq seq1 #seq2 seq3
+    `;
+
+    const ast = parseWithPeggy(code);
+    const resolved = resolveSong(ast);
+
+    // Channel 1 should only have 2 notes (from pattern 'a')
+    const ch1 = resolved.channels.find((ch: any) => ch.id === 1);
+    expect(ch1).toBeDefined();
+    
+    const noteEvents = ch1!.events.filter((e: any) => e.type === 'note') as NoteEvent[];
+    expect(noteEvents).toHaveLength(2);
+    expect(noteEvents[0].token).toBe('C4');
+    expect(noteEvents[1].token).toBe('E4');
+  });
+
+  it('should handle inline comments with //', () => {
+    const code = `
+      chip gameboy
+      bpm 120
+      
+      inst test type=pulse1 duty=50 env=10,flat
+      
+      pat a = C4 E4
+      pat b = G4 B4
+      
+      seq seq1 = a
+      seq seq2 = b
+      
+      channel 1 => inst test seq seq1 //seq2
+    `;
+
+    const ast = parseWithPeggy(code);
+    const resolved = resolveSong(ast);
+
+    const ch1 = resolved.channels.find((ch: any) => ch.id === 1);
+    expect(ch1).toBeDefined();
+    
+    const noteEvents = ch1!.events.filter((e: any) => e.type === 'note') as NoteEvent[];
+    expect(noteEvents).toHaveLength(2);
+    expect(noteEvents[0].token).toBe('C4');
+    expect(noteEvents[1].token).toBe('E4');
+  });
+});

--- a/songs/effects/volume_slide.bax
+++ b/songs/effects/volume_slide.bax
@@ -1,0 +1,70 @@
+## Demo: Volume Slide (volSlide) effect example
+## Exercises inline `volSlide` parameters and vibrato
+## Play: node bin/beatbax play songs/effects/volume_slide.bax
+
+chip gameboy
+bpm 120
+
+## Instruments
+## Note: Using moderate initial volumes (env=10 for lead, volume=50 for pad)
+## to allow headroom for volume slides in both directions (+/- deltas)
+inst lead     type=pulse1 duty=50 env=8,flat    # For normal play
+inst lead_in  type=pulse1 duty=50 env=4,flat    # For fade-ins
+inst lead_out type=pulse1 duty=50 env=12,flat   # For fade-outs
+
+inst bass type=pulse2 duty=25 env=5,flat   # Start at 80% - good range for slides
+inst pad  type=wave   wave=[0,3,6,9,12,15,12,9,6,3,0,3,6,9,12,15] volume=50  # Start at 50% - room for swells
+inst perc type=noise  env=8,down            # Start at 53% - moderate percussion
+
+## Named volume slide presets
+effect fadeIn  = volSlide:+5
+effect fadeOut = volSlide:-5
+effect fastFadeOut = volSlide:-8
+effect subtleFade = volSlide:+4
+
+## Pattern 1: Basic fade in (positive delta)
+pat melody_in = C4<volSlide:+12>:8 E4<volSlide:+12>:8 G4<volSlide:+12>:8 C5<volSlide:+12>:8
+
+## Pattern 2: Basic fade out (negative delta)
+pat melody_out = C5<volSlide:-3>:8 G4<volSlide:-3>:8 E4<volSlide:-3>:8 C4<volSlide:-3>:8
+
+## Pattern 3: Using named effect presets
+pat fade_demo = C4<fadeIn>:4 E4:4 G4<fadeOut>:4 C5<fastFadeOut>:4
+
+## Pattern 4: Stepped volume slide (with step count)
+## Fewer steps (4) over longer duration (16 ticks) makes steps more audible
+## Uses lead_in for fade-in (C4) and lead_out for fade-out (E4)
+pat stepped = inst(lead_in,1) C4<volSlide:+,4>:16 inst(lead_out,1) E4<volSlide:-8,4>:16
+
+## Pattern 4b: Comparing smooth vs stepped slides
+## First note: smooth fade (1 param), Second note: stepped fade (2 params)
+pat compare = inst(lead_in,2) C4<volSlide:+14>:12 . C4<volSlide:+14,4>:12 inst(lead_out,2) C4<volSlide:-12>:12 . C4<volSlide:-12,4>:12
+
+## Pattern 5: Combination with other effects
+pat combo = C4<vib:3,6,volSlide:+3>:4 E4<port:12,volSlide:-2>:4 G4<arp:3,7,volSlide:+4>:4
+
+## Pattern 6: Bass with fade
+pat bass_pat = C2<volSlide:+8>:4 C2<volSlide:-8>:4 G2<volSlide:+3>:4 G2<volSlide:-3>:4
+
+## Pattern 7: Pad with gentle swell
+pat pad_swell = C3<subtleFade>:8 E3<volSlide:-2>:8
+
+## Pattern 8: Percussion with decay reinforcement
+pat perc_pat = C7<volSlide:-6>:2 . .  C7<volSlide:-12>:2 . .
+
+## Sequences
+seq intro  = melody_in:inst(lead_in) melody_out:inst(lead_out)
+seq chorus = fade_demo stepped compare
+seq bridge = combo*2
+seq outro  = melody_out:inst(lead_out)
+seq bass_loop = bass_pat*8
+seq pad_loop = pad_swell*8
+seq perc_loop = perc_pat*16
+
+# Channel assignments
+channel 1 => inst lead seq intro outro
+channel 2 => inst bass seq bass_loop
+channel 3 => inst pad  seq pad_loop
+channel 4 => inst perc seq perc_loop
+
+play

--- a/songs/percussion_demo.bax
+++ b/songs/percussion_demo.bax
@@ -5,6 +5,14 @@
 ## - Kick drums on pulse channels (low pitch + fast envelope)
 ## - Snares on noise channel (7-bit mode, octaves 4-5) for an explosive sound
 ## - Hi-hats on noise channel (15-bit mode, octaves 6-7) for a more traditional percussive sound
+##
+## NOTE MAPPING FOR UGE EXPORT:
+## - Pulse channels: Notes map directly (C2 in BeatBax → index 0 in hUGETracker = C-3)
+## - Noise channel: NO automatic transpose applied
+##   - C2 → index 0 (C-3 in hUGETracker notation)
+##   - C5 → index 24 (C-5 in hUGETracker notation)
+##   - C7 → index 48 (C-7 in hUGETracker notation)
+##   Write notes in the range you want to hear in hUGETracker
 
 song name "Percussion Demo"
 song artist "kadraman"
@@ -32,6 +40,13 @@ inst kick_soft   type=pulse1 duty=25   env={"level":12,"direction":"down","perio
 # Notes in hUGETracker are "brightness labels", not harmonic pitches
 # They map to NR43 register values (shift + divider combinations)
 # Use gb:width=7 for metallic/tonal, gb:width=15 for pure white noise
+#
+# UGE EXPORT NOTE MAPPING:
+# BeatBax notes export 1:1 to hUGETracker indices (NO automatic transpose)
+# - C2 = index 0 (lowest noise sound)
+# - C5 = index 24 (mid-range)
+# - C7 = index 48 (high)
+# Write notes in the exact octave range you want in hUGETracker
 
 # Snare drums (7-bit mode with length control)
 inst snare_tight type=noise gb:width=7 env={"level":13,"direction":"down","period":1,"format":"gb"} length=16  # Tight snare (quick decay, short)


### PR DESCRIPTION
<!-- Describe the purpose of this PR and the changes it makes. -->

### Summary

- Implement volSlide effect (smooth/stepped) with WebAudio, PCM, UGE, MIDI export
- BREAKING: Remove noise channel auto-transpose; use 1:1 mapping (C2→0, C7→48)
- Add 'flat' envelope direction for constant volume instruments
- Improve validation with source locations and web UI warnings
- 27 files changed: engine, CLI, web-ui, docs, tests

### Checklist

- [x] My changes add required tests and they pass.
- [x] I ran `npm test` locally and all tests passed.
- [x] I updated README or docs if required.
- [x] This PR follows repository coding style and guidelines.

### Notes for reviewers

None.
