### PR TITLE
feat(web-ui,engine,docs,songs): add rich BeatBax hovers, playback UI upgrades, and wave demo updates

### DIFF
--- a/.changeset/khaki-views-fall.md
+++ b/.changeset/khaki-views-fall.md
@@ -1,0 +1,5 @@
+---
+"@beatbax/engine": patch
+---
+
+updates to gameboy ui contributons and copilot

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import "github:beatbax/instruments-gb/main/melodic.ins"
 # Instruments
 inst lead  type=pulse1 duty=50  env={"level":12,"direction":"down","period":1,"format":"gb"}
 inst bass  type=pulse2 duty=25  env={"level":10,"direction":"down","period":1,"format":"gb"}
-inst wave1 type=wave   wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave   wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst snare type=noise  env={"level":12,"direction":"down","period":1,"format":"gb"}
 
 # Named effect presets

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -882,13 +882,6 @@ The transport bar's `«` and `»` buttons step the playback tempo down or up by 
 - Instrument resolution is automatic: the preview borrows the instrument already associated with the pattern or sequence in a channel declaration; otherwise the first declared instrument is used.
 - Only one preview plays at a time. Starting a new preview stops the previous one.
 
-**Play selected sequence / pattern** — quickly audition any subset of your song without editing the channel layout:
-1. Select one or more `pat` or `seq` definition lines in the editor (click-drag, or hold `Shift` and click).
-2. Press `Ctrl+Shift+Space`, or right-click and choose **▶ Play Selected Sequence / Pattern**.
-3. Each selected item plays on its own channel simultaneously. If you select more sequences than the chip has channels (4 for Game Boy), the extras are distributed round-robin — the first seq on each channel plays first, then the overflow seqs chain on automatically.
-4. The glyph-margin play indicators light up on the original `seq` lines as each one becomes active, tracking through merged channels accurately.
-5. Press `Escape` to stop playback at any time.
-
 **BeatBax command palette** — press `F1` (or `Ctrl+Alt+P`) inside the editor and type `BeatBax` to see all available commands:
 
 | Command | Description |

--- a/apps/web-ui/src/editor/beatbax-language.ts
+++ b/apps/web-ui/src/editor/beatbax-language.ts
@@ -26,52 +26,79 @@ interface WaveHoverParseResult {
   hoveredIndex: number | null;
 }
 
+interface QuoteScanState {
+  inDouble: boolean;
+  inTriple: boolean;
+}
+
+function scanQuoteState(text: string, initial: QuoteScanState): QuoteScanState {
+  let i = 0;
+  let inDouble = initial.inDouble;
+  let inTriple = initial.inTriple;
+
+  while (i < text.length) {
+    // Triple-quote delimiter toggles multiline-string mode.
+    if (!inDouble && text.substring(i, i + 3) === '"""') {
+      inTriple = !inTriple;
+      i += 3;
+      continue;
+    }
+
+    // Normal double-quoted strings are tracked only outside triple-quote mode.
+    if (!inTriple && text[i] === '"' && (i === 0 || text[i - 1] !== '\\')) {
+      inDouble = !inDouble;
+    }
+
+    i += 1;
+  }
+
+  return { inDouble, inTriple };
+}
+
 /**
- * Check if a position is inside a quoted string (single or triple-quoted).
+ * Check if a position is inside a quoted string (double or triple-quoted).
  * Can work with either a line string directly or via Monaco model + position.
  */
 function isPositionInString(
   modelOrLine: monaco.editor.ITextModel | string,
   positionOrColumn?: monaco.IPosition | number,
 ): boolean {
-  let line: string;
-  let column: number;
-
-  // Overload: (ITextModel, IPosition) or (string, number)
+  // Overload: (string, number)
   if (typeof modelOrLine === 'string') {
-    line = modelOrLine;
-    column = (positionOrColumn as number) || 0;
-  } else {
-    // It's an ITextModel
-    const model = modelOrLine as monaco.editor.ITextModel;
-    const position = positionOrColumn as monaco.IPosition;
-    line = model.getLineContent(position.lineNumber);
-    column = position.column;
+    const line = modelOrLine;
+    const column = (positionOrColumn as number) || 0;
+    const upToCursor = line.substring(0, Math.max(0, column - 1));
+    const state = scanQuoteState(upToCursor, { inDouble: false, inTriple: false });
+    return state.inDouble || state.inTriple;
   }
 
-  // Scan from line start to cursor position to count quote pairs
-  const upToCursor = line.substring(0, column - 1);
+  // Overload: (ITextModel, IPosition)
+  const model = modelOrLine as monaco.editor.ITextModel;
+  const position = positionOrColumn as monaco.IPosition;
 
-  let i = 0;
-  let inSingleQuote = false;
+  // If a lightweight mock omits getLineCount, gracefully fall back to line-local scan.
+  if (typeof model.getLineCount !== 'function') {
+    const line = model.getLineContent(position.lineNumber);
+    const upToCursor = line.substring(0, Math.max(0, position.column - 1));
+    const state = scanQuoteState(upToCursor, { inDouble: false, inTriple: false });
+    return state.inDouble || state.inTriple;
+  }
 
-  while (i < upToCursor.length) {
-    // Check for triple quotes first
-    if (upToCursor.substring(i, i + 3) === '"""') {
-      inSingleQuote = !inSingleQuote;
-      i += 3;
-    } else if (upToCursor[i] === '"') {
-      // Only toggle single quotes if NOT in triple-quote mode
-      if (!inSingleQuote || upToCursor.substring(i - 2, i) !== '""') {
-        inSingleQuote = !inSingleQuote;
-      }
-      i += 1;
-    } else {
-      i += 1;
+  let state: QuoteScanState = { inDouble: false, inTriple: false };
+
+  for (let lineNo = 1; lineNo <= model.getLineCount(); lineNo++) {
+    const line = model.getLineContent(lineNo);
+    if (lineNo < position.lineNumber) {
+      state = scanQuoteState(line, state);
+      continue;
     }
+
+    const upToCursor = line.substring(0, Math.max(0, position.column - 1));
+    const cursorState = scanQuoteState(upToCursor, state);
+    return cursorState.inDouble || cursorState.inTriple;
   }
 
-  return inSingleQuote;
+  return false;
 }
 
 function parseWaveLiteralAtPosition(
@@ -1249,9 +1276,11 @@ export function registerBeatBaxLanguage(): void {
       const tokens: number[] = [];
       let prevLine = 0;
       let prevChar = 0;
+      let quoteState: QuoteScanState = { inDouble: false, inTriple: false };
 
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
+        const lineStartState = quoteState;
 
         // Skip comments early
         const commentIdx = line.indexOf('#');
@@ -1270,7 +1299,9 @@ export function registerBeatBaxLanguage(): void {
           if (typeIdx !== -1) {
             // Skip semantic coloring if this identifier is inside a quoted string (metadata)
             const matchColumn = match.index + 1; // Monaco columns are 1-indexed
-            if (isPositionInString(line, matchColumn)) {
+            const preToken = line.substring(0, Math.max(0, matchColumn - 1));
+            const tokenState = scanQuoteState(preToken, lineStartState);
+            if (tokenState.inDouble || tokenState.inTriple) {
               continue;
             }
 
@@ -1286,6 +1317,8 @@ export function registerBeatBaxLanguage(): void {
             prevChar = startChar;
           }
         }
+
+        quoteState = scanQuoteState(line, lineStartState);
       }
 
       const result = new Uint32Array(tokens);

--- a/apps/web-ui/src/editor/beatbax-language.ts
+++ b/apps/web-ui/src/editor/beatbax-language.ts
@@ -20,6 +20,492 @@ eventBus.on('parse:success', ({ ast }) => {
 /** Cached semantic-token result. Invalidated whenever the model version changes. */
 let tokenCache: { versionId: number; data: Uint32Array } | null = null;
 
+interface WaveHoverParseResult {
+  values: number[];
+  range: monaco.IRange;
+  hoveredIndex: number | null;
+}
+
+/**
+ * Check if a position is inside a quoted string (single or triple-quoted).
+ * Can work with either a line string directly or via Monaco model + position.
+ */
+function isPositionInString(
+  modelOrLine: monaco.editor.ITextModel | string,
+  positionOrColumn?: monaco.IPosition | number,
+): boolean {
+  let line: string;
+  let column: number;
+
+  // Overload: (ITextModel, IPosition) or (string, number)
+  if (typeof modelOrLine === 'string') {
+    line = modelOrLine;
+    column = (positionOrColumn as number) || 0;
+  } else {
+    // It's an ITextModel
+    const model = modelOrLine as monaco.editor.ITextModel;
+    const position = positionOrColumn as monaco.IPosition;
+    line = model.getLineContent(position.lineNumber);
+    column = position.column;
+  }
+
+  // Scan from line start to cursor position to count quote pairs
+  const upToCursor = line.substring(0, column - 1);
+
+  let i = 0;
+  let inSingleQuote = false;
+
+  while (i < upToCursor.length) {
+    // Check for triple quotes first
+    if (upToCursor.substring(i, i + 3) === '"""') {
+      inSingleQuote = !inSingleQuote;
+      i += 3;
+    } else if (upToCursor[i] === '"') {
+      // Only toggle single quotes if NOT in triple-quote mode
+      if (!inSingleQuote || upToCursor.substring(i - 2, i) !== '""') {
+        inSingleQuote = !inSingleQuote;
+      }
+      i += 1;
+    } else {
+      i += 1;
+    }
+  }
+
+  return inSingleQuote;
+}
+
+function parseWaveLiteralAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): WaveHoverParseResult | null {
+  const line = model.getLineContent(position.lineNumber);
+  const waveRegex = /\bwave\s*=\s*\[([^\]]*)\]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = waveRegex.exec(line)) !== null) {
+    const matchText = match[0];
+    const openBracketRel = matchText.indexOf('[');
+    if (openBracketRel < 0) continue;
+
+    const openBracketIdx = match.index + openBracketRel;
+    const closeBracketIdx = line.indexOf(']', openBracketIdx);
+    if (closeBracketIdx < 0) continue;
+
+    const column0 = position.column - 1;
+    if (column0 < openBracketIdx || column0 > closeBracketIdx + 1) continue;
+
+    const inner = line.slice(openBracketIdx + 1, closeBracketIdx);
+    const numberRegex = /-?\d+(?:\.\d+)?/g;
+    const values: number[] = [];
+    let hoveredIndex: number | null = null;
+    let n: RegExpExecArray | null;
+
+    while ((n = numberRegex.exec(inner)) !== null) {
+      const parsed = Number(n[0]);
+      if (!Number.isFinite(parsed)) continue;
+
+      const idx = values.length;
+      values.push(parsed);
+
+      const tokenStartIdx = openBracketIdx + 1 + n.index;
+      const tokenStartCol = tokenStartIdx + 1;
+      const tokenEndCol = tokenStartCol + n[0].length;
+      if (position.column >= tokenStartCol && position.column <= tokenEndCol) {
+        hoveredIndex = idx;
+      }
+    }
+
+    if (values.length === 0) return null;
+
+    return {
+      values,
+      hoveredIndex,
+      range: {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: openBracketIdx + 1,
+        endColumn: closeBracketIdx + 2,
+      },
+    };
+  }
+
+  return null;
+}
+
+function renderWaveSparkline(values: number[], hoveredIndex: number | null): string {
+  const levels = ' ▁▂▃▄▅▆▇█';
+  const clamped = values.map((v) => Math.max(0, Math.min(15, Math.round(v))));
+  const line = clamped
+    .map((v) => {
+      const level = Math.round((v / 15) * 8);
+      return levels[level] ?? levels[0];
+    })
+    .join('');
+
+  if (hoveredIndex === null || hoveredIndex < 0 || hoveredIndex >= clamped.length) {
+    return line;
+  }
+
+  const marker = `${' '.repeat(hoveredIndex)}^`;
+  return `${line}\n${marker}`;
+}
+
+function buildWaveHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): monaco.languages.Hover | null {
+  const parsed = parseWaveLiteralAtPosition(model, position);
+  if (!parsed) return null;
+
+  const clamped = parsed.values.map((v) => Math.max(0, Math.min(15, Math.round(v))));
+  const min = Math.min(...clamped);
+  const max = Math.max(...clamped);
+
+  let meta = `Samples: ${parsed.values.length}  Clamped range: ${min}..${max}`;
+  if (parsed.hoveredIndex !== null) {
+    const raw = parsed.values[parsed.hoveredIndex];
+    const clampedValue = clamped[parsed.hoveredIndex];
+    meta += `\nIndex ${parsed.hoveredIndex}: raw=${raw} clamped=${clampedValue}`;
+  }
+
+  return {
+    range: parsed.range,
+    contents: [
+      { value: '**Waveform preview**' },
+      { value: `\`\`\`text\n${renderWaveSparkline(parsed.values, parsed.hoveredIndex)}\n\`\`\`` },
+      { value: meta },
+    ],
+  };
+}
+
+// ── Envelope hover ───────────────────────────────────────────────────────────
+
+interface ParsedEnvelope {
+  /** Initial volume level 0–15. */
+  level: number;
+  /** 'up' | 'down' | 'flat'. */
+  direction: 'up' | 'down' | 'flat';
+  /** Envelope period 0–7. 0 = constant (no sweep). */
+  period: number;
+  /** Source string, used for display. */
+  raw: string;
+  /** Monaco range covering the full env=... value token. */
+  range: monaco.IRange;
+}
+
+/**
+ * Detect and parse the `env=` value when the cursor sits anywhere inside it.
+ * Handles three formats:
+ *   - JSON object:  env={"level":12,"direction":"down","period":1}
+ *   - gb-prefixed:  env=gb:12,down,1
+ *   - short form:   env=12,down,1   or  env=12,down
+ */
+export function parseEnvelopeAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): ParsedEnvelope | null {
+  const line = model.getLineContent(position.lineNumber);
+  const col0 = position.column - 1; // 0-based
+
+  // ── JSON form: env={...} ─────────────────────────────────────────────────
+  const jsonEnvRe = /\benv\s*=\s*(\{[^}]*\})/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = jsonEnvRe.exec(line)) !== null) {
+    const tokenStart = m.index;
+    const tokenEnd = m.index + m[0].length - 1;
+    if (col0 < tokenStart || col0 > tokenEnd) continue;
+
+    try {
+      const obj = JSON.parse(m[1]);
+      const level = Number(obj.level ?? obj.initial ?? 15);
+      const rawDir: string = String(obj.direction ?? 'down').toLowerCase();
+      const direction = rawDir === 'up' ? 'up' : rawDir === 'flat' ? 'flat' : 'down';
+      const period = Number(obj.period ?? obj.step ?? 0);
+      return {
+        level: Math.max(0, Math.min(15, level)),
+        direction,
+        period: Math.max(0, Math.min(7, period)),
+        raw: m[1],
+        range: {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: tokenStart + 1,
+          endColumn: tokenEnd + 2,
+        },
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  // ── gb-prefixed or short form: env=gb:L,dir,period or env=L,dir[,period] ─
+  // Match everything after `env=` up to next whitespace or end-of-line
+  const shortEnvRe = /\benv\s*=\s*((?:gb:)?\S+)/g;
+  while ((m = shortEnvRe.exec(line)) !== null) {
+    const tokenStart = m.index;
+    const tokenEnd = m.index + m[0].length - 1;
+    if (col0 < tokenStart || col0 > tokenEnd) continue;
+
+    let raw = m[1];
+    if (raw.startsWith('gb:')) raw = raw.slice(3);
+    if (raw.startsWith('"') || raw.startsWith('{')) continue; // already handled above
+
+    const parts = raw.split(',');
+    const level = Math.max(0, Math.min(15, parseInt(parts[0] ?? '15', 10)));
+    const rawDir = (parts[1] ?? 'down').toLowerCase();
+    const direction: 'up' | 'down' | 'flat' =
+      rawDir === 'up' ? 'up' : rawDir === 'flat' ? 'flat' : 'down';
+    const period = Math.max(0, Math.min(7, parseInt(parts[2] ?? '0', 10)));
+
+    if (Number.isNaN(level)) continue;
+
+    return {
+      level,
+      direction,
+      period,
+      raw: m[1],
+      range: {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: tokenStart + 1,
+        endColumn: tokenEnd + 2,
+      },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Simulate a Game Boy NR5x hardware envelope and return the volume level
+ * at each tick step (one step = one NR52 envelope tick, ~1/64 s).
+ * Returns 20 steps, which is enough to show the full decay/attack.
+ */
+export function simulateGBEnvelope(env: ParsedEnvelope, steps = 20): number[] {
+  const result: number[] = [];
+  let vol = env.level;
+
+  for (let t = 0; t < steps; t++) {
+    result.push(vol);
+
+    if (env.period === 0 || env.direction === 'flat') continue;
+
+    // GB envelope: volume changes every `period` steps
+    if ((t + 1) % env.period === 0) {
+      if (env.direction === 'up') {
+        vol = Math.min(15, vol + 1);
+      } else {
+        vol = Math.max(0, vol - 1);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Render a horizontal level sparkline for an envelope volume curve.
+ * Each character represents one step; height encodes level 0–15.
+ */
+export function renderEnvelopeSparkline(levels: number[]): string {
+  const chars = ' ▁▂▃▄▅▆▇█';
+  return levels
+    .map((v) => {
+      const idx = Math.round(Math.max(0, Math.min(15, v)) / 15 * 8);
+      return chars[idx] ?? chars[0];
+    })
+    .join('');
+}
+
+function buildEnvelopeHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): monaco.languages.Hover | null {
+  const env = parseEnvelopeAtPosition(model, position);
+  if (!env) return null;
+
+  const steps = simulateGBEnvelope(env, 32);
+  const sparkline = renderEnvelopeSparkline(steps);
+
+  const dirLabel = env.direction === 'flat' ? 'flat (constant)' : env.direction;
+  const periodLabel =
+    env.period === 0
+      ? '0 (constant — no sweep)'
+      : `${env.period} (changes every ${env.period} step${env.period > 1 ? 's' : ''})`;
+
+  const meta = [
+    `Initial level: **${env.level}** / 15`,
+    `Direction: **${dirLabel}**`,
+    `Period: **${periodLabel}**`,
+  ].join('  \n');
+
+  return {
+    range: env.range,
+    contents: [
+      { value: '**Envelope preview** (GB hardware simulation, 32 steps)' },
+      { value: `\`\`\`text\n${sparkline}\n\`\`\`` },
+      { value: meta },
+    ],
+  };
+}
+
+// ── NES macro envelope hover ──────────────────────────────────────────────────
+
+const NES_MACRO_TYPES = ['vol_env', 'arp_env', 'pitch_env', 'duty_env'] as const;
+type NesMacroType = (typeof NES_MACRO_TYPES)[number];
+
+export interface ParsedNesMacro {
+  /** Which macro field was matched. */
+  macroType: NesMacroType;
+  /** Parsed numeric values. */
+  values: number[];
+  /** Index to loop back to at end of sequence; -1 = one-shot. */
+  loopPoint: number;
+  /** Monaco range covering the entire `field=[...]` token. */
+  range: monaco.IRange;
+}
+
+/**
+ * Detect and parse a NES software-macro field when the cursor sits anywhere inside
+ * `vol_env=[...]`, `arp_env=[...]`, `pitch_env=[...]`, or `duty_env=[...]`.
+ * Supports the optional loop-point suffix: `[v0,v1,...|loopIndex]`.
+ */
+export function parseNesMacroAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): ParsedNesMacro | null {
+  const line = model.getLineContent(position.lineNumber);
+  const col0 = position.column - 1; // 0-based
+
+  for (const macroType of NES_MACRO_TYPES) {
+    const re = new RegExp(`\\b${macroType}\\s*=\\s*(\\[[^\\]]*\\])`, 'g');
+    let m: RegExpExecArray | null;
+
+    while ((m = re.exec(line)) !== null) {
+      const tokenStart = m.index;
+      const tokenEnd = m.index + m[0].length - 1;
+      if (col0 < tokenStart || col0 > tokenEnd) continue;
+
+      const inner = m[1].slice(1, -1); // strip [ and ]
+
+      // Split at optional loop-point separator `|N`
+      let loopPoint = -1;
+      let contentStr = inner;
+      const pipeIdx = inner.lastIndexOf('|');
+      if (pipeIdx >= 0) {
+        const lpNum = parseInt(inner.slice(pipeIdx + 1).trim(), 10);
+        if (!isNaN(lpNum) && lpNum >= 0) loopPoint = lpNum;
+        contentStr = inner.slice(0, pipeIdx);
+      }
+
+      const values = contentStr
+        .split(',')
+        .map((s) => parseFloat(s.trim()))
+        .filter(Number.isFinite);
+
+      if (values.length === 0) continue;
+      if (loopPoint >= values.length) loopPoint = values.length - 1;
+
+      return {
+        macroType,
+        values,
+        loopPoint,
+        range: {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: tokenStart + 1,
+          endColumn: tokenEnd + 2,
+        },
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Render a sparkline for an arbitrary array of values, normalizing to [min, max]. */
+export function renderNesMacroSparkline(values: number[], min: number, max: number): string {
+  const chars = ' ▁▂▃▄▅▆▇█';
+  const range = max - min || 1;
+  return values
+    .map((v) => {
+      const normalized = (Math.max(min, Math.min(max, v)) - min) / range;
+      const idx = Math.round(normalized * 8);
+      return chars[idx] ?? chars[0];
+    })
+    .join('');
+}
+
+const DUTY_INDEX_LABELS = ['12.5%', '25%', '50%', '75%'];
+
+function buildNesMacroHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): monaco.languages.Hover | null {
+  const macro = parseNesMacroAtPosition(model, position);
+  if (!macro) return null;
+
+  let title: string;
+  let sparkline: string;
+  let meta: string;
+
+  const loopStr =
+    macro.loopPoint >= 0
+      ? `Loops from index **${macro.loopPoint}**`
+      : 'One-shot (no loop — holds last value)';
+
+  switch (macro.macroType) {
+    case 'vol_env': {
+      const clamped = macro.values.map((v) => Math.max(0, Math.min(15, Math.round(v))));
+      title = '**Volume envelope** (NES macro, per-frame, 0–15)';
+      sparkline = renderNesMacroSparkline(clamped, 0, 15);
+      const lo = Math.min(...clamped), hi = Math.max(...clamped);
+      meta = `Frames: **${clamped.length}**  Range: **${lo}–${hi}** / 15  \n${loopStr}`;
+      break;
+    }
+    case 'arp_env': {
+      title = '**Arpeggio envelope** (NES macro, semitone offsets from root)';
+      const lo = Math.min(...macro.values, 0);
+      const hi = Math.max(...macro.values, 0);
+      sparkline = renderNesMacroSparkline(macro.values, lo, hi);
+      const valStr = macro.values.map((v) => (v >= 0 ? `+${v}` : `${v}`)).join(', ');
+      meta = `Frames: **${macro.values.length}**  Offsets (semitones): ${valStr}  \n${loopStr}`;
+      break;
+    }
+    case 'pitch_env': {
+      title = '**Pitch envelope** (NES macro, semitone offsets from root)';
+      const lo = Math.min(...macro.values, 0);
+      const hi = Math.max(...macro.values, 0);
+      sparkline = renderNesMacroSparkline(macro.values, lo, hi);
+      const valStr = macro.values.map((v) => (v >= 0 ? `+${v}` : `${v}`)).join(', ');
+      meta = [
+        `Frames: **${macro.values.length}**  Offsets (semitones): ${valStr}`,
+        loopStr,
+        '_Note: FamiTracker PITCH macro uses 1/16-semitone units — each value is multiplied by 16 on export._',
+      ].join('  \n');
+      break;
+    }
+    case 'duty_env': {
+      const clamped = macro.values.map((v) => Math.max(0, Math.min(3, Math.round(v))));
+      title = '**Duty envelope** (NES macro, duty indices 0–3)';
+      sparkline = renderNesMacroSparkline(clamped, 0, 3);
+      const dutyStr = clamped.map((v) => DUTY_INDEX_LABELS[v] ?? String(v)).join(', ');
+      meta = `Frames: **${clamped.length}**  Duty cycle sequence: ${dutyStr}  \n${loopStr}`;
+      break;
+    }
+  }
+
+  return {
+    range: macro.range,
+    contents: [
+      { value: title },
+      { value: `\`\`\`text\n${sparkline}\n\`\`\`` },
+      { value: meta },
+    ],
+  };
+}
+
 /**
  * Register BeatBax language with Monaco
  */
@@ -355,7 +841,7 @@ export function registerBeatBaxLanguage(): void {
         {
           label: 'inst (wave)',
           detail: 'Define wave instrument',
-          insertText: 'inst ${1:name} type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]',
+          insertText: 'inst ${1:name} type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]',
           insertTextRules:
             monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
         },
@@ -472,6 +958,15 @@ export function registerBeatBaxLanguage(): void {
   // Register hover provider
   monaco.languages.registerHoverProvider('beatbax', {
     provideHover: (model, position) => {
+      const waveHover = buildWaveHover(model, position);
+      if (waveHover) return waveHover;
+
+      const envelopeHover = buildEnvelopeHover(model, position);
+      if (envelopeHover) return envelopeHover;
+
+      const nesMacroHover = buildNesMacroHover(model, position);
+      if (nesMacroHover) return nesMacroHover;
+
       const word = model.getWordAtPosition(position);
       if (!word) return null;
 
@@ -630,6 +1125,11 @@ export function registerBeatBaxLanguage(): void {
         };
       }
 
+      // Skip instrument/effect hovers if cursor is inside a quoted string (e.g., metadata)
+      if (isPositionInString(model, position)) {
+        return null;
+      }
+
       if (latestAST?.insts && latestAST.insts[word.word]) {
         const inst = latestAST.insts[word.word];
         const props: string[] = [];
@@ -768,6 +1268,12 @@ export function registerBeatBaxLanguage(): void {
           else if (sequences.has(word)) typeIdx = 2;
 
           if (typeIdx !== -1) {
+            // Skip semantic coloring if this identifier is inside a quoted string (metadata)
+            const matchColumn = match.index + 1; // Monaco columns are 1-indexed
+            if (isPositionInString(line, matchColumn)) {
+              continue;
+            }
+
             const startChar = match.index;
             const length = word.length;
 

--- a/apps/web-ui/src/editor/command-palette.ts
+++ b/apps/web-ui/src/editor/command-palette.ts
@@ -66,7 +66,7 @@ export interface CommandPaletteOptions {
 
 const SAMPLE_INST_SNIPPET = `inst lead  type=pulse1 duty=50 env=12,down
 inst bass  type=pulse2 duty=25 env=10,down
-inst wave1 type=wave   wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave   wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst sn    type=noise  env=12,down
 `;
 
@@ -286,6 +286,7 @@ export function setupCommandPalette(opts: CommandPaletteOptions): monaco.IDispos
 
   // ── BeatBax: Edit — play selection ────────────────────────────────────────
 
+  /*
   reg({
     id: 'beatbax.playSelection',
     label: 'BeatBax: Play Selected Sequence / Pattern',
@@ -344,7 +345,7 @@ export function setupCommandPalette(opts: CommandPaletteOptions): monaco.IDispos
       ].join('\n');
       onPlayRaw?.(syntheticSource);
     },
-  });
+  });*/
 
   // ── BeatBax: Edit — format document ──────────────────────────────────────
 

--- a/apps/web-ui/src/editor/glyph-margin.ts
+++ b/apps/web-ui/src/editor/glyph-margin.ts
@@ -11,7 +11,8 @@
  *    `playback:position-changed` event and clear on `playback:stopped`.
  *
  * 2. Channel mute / solo indicator
- *    A ♩ (live), ⊘ (muted), or ★ (soloed) glyph on every `channel N =>`
+ *    Two boxed state badges on every `channel N =>` line:
+ *    left lane = Mute (M), right lane = Solo (S).
  *    line reflects current mute/solo state.  Clicking the glyph toggles
  *    mute for that channel, providing a quick in-editor shortcut without
  *    needing to reach for the Channel Mixer.  Glyphs rebuild on
@@ -43,9 +44,10 @@ function injectGlyphStyles(): void {
     /* Centre the ::before badge inside Monaco's glyph container */
     .bb-glyph--playing,
     .bb-glyph--seq-playing,
-    .bb-glyph--ch-live,
-    .bb-glyph--ch-muted,
-    .bb-glyph--ch-soloed {
+    .bb-glyph--ch-mute-off,
+    .bb-glyph--ch-mute-on,
+    .bb-glyph--ch-solo-off,
+    .bb-glyph--ch-solo-on {
       display: flex !important;
       align-items: center;
       justify-content: center;
@@ -54,9 +56,10 @@ function injectGlyphStyles(): void {
     /* ── Shared badge base ─────────────────────────────────────── */
     .bb-glyph--playing::before,
     .bb-glyph--seq-playing::before,
-    .bb-glyph--ch-live::before,
-    .bb-glyph--ch-muted::before,
-    .bb-glyph--ch-soloed::before {
+    .bb-glyph--ch-mute-off::before,
+    .bb-glyph--ch-mute-on::before,
+    .bb-glyph--ch-solo-off::before,
+    .bb-glyph--ch-solo-on::before {
       display: block;
       width: 16px;
       height: 15px;
@@ -95,42 +98,44 @@ function injectGlyphStyles(): void {
       animation-delay: 0.45s;
     }
 
-    /* ── Channel live (normal) ─────────────────────────────────── */
-    .bb-glyph--ch-live::before {
-      content: '';
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTEwLjUgM0w1IDYuNXY1LjVDNSAxMy42IDQuNiAxNCAzLjUgMTRTMiAxMy42IDIgMTIuNXMxLS0xLjUgMi4xLTEuNWMuNyAwIDEuMy4yIDEuOC42VjcuMWw0LjUtMi45djVjMCAxIC0uOSA0LjUtMiA0LjVTMTAuNSAxMy42IDEwLjUgMTIuNXMxLS0xLjUgMi4xLS0xLjVjLjcgMCAxLjMuMiAxLjguNlYzWiIgZmlsbD0iIzRjYWY1MCIvPjwvc3ZnPg==');
-      background-repeat: no-repeat;
-      background-position: center;
-      border: 1px solid #555;
-      background-color: #3a3a3a;
+    /* ── Channel mute button (left lane) ───────────────────────── */
+    .bb-glyph--ch-mute-off::before {
+      content: 'M';
+      color: #9a9a9a;
+      border: 1px solid #6b6b6b;
+      background-color: #2f2f2f;
       border-radius: 3px;
     }
 
-    /* ── Channel muted ─────────────────────────────────────────── */
-    .bb-glyph--ch-muted::before {
-      content: '';
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTUgNCBMNyA4IEw1IDEyIEw3IDEzIEw5IDkuNSBMMTEgMTMgTDEzIDEyIEwxMSA4IEwxMyA0IEwxMSA0IEw5LjUgNiBMNyAzIFoiIGZpbGw9IiNmZmFhYWEiLz48L3N2Zz4=');
-      background-repeat: no-repeat;
-      background-position: center;
+    .bb-glyph--ch-mute-on::before {
+      content: 'M';
+      color: #ffd2d2;
       border: 1px solid #c94e4e;
       background-color: #7a2f2f;
       border-radius: 3px;
     }
 
-    /* ── Channel soloed ────────────────────────────────────────── */
-    .bb-glyph--ch-soloed::before {
-      content: '';
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTggMSBMMTAgNiBMMTUgNiBMMTEgOSBMMTIgMTQgTDggMTEgTDQgMTQgTDUgOSBMMSA2IEw2IDYgWiIgZmlsbD0iIzljZGNmZSIvPjwvc3ZnPg==');
-      background-repeat: no-repeat;
-      background-position: center;
+    /* ── Channel solo button (right lane) ──────────────────────── */
+    .bb-glyph--ch-solo-off::before {
+      content: 'S';
+      color: #9a9a9a;
+      border: 1px solid #6b6b6b;
+      background-color: #2f2f2f;
+      border-radius: 3px;
+    }
+
+    .bb-glyph--ch-solo-on::before {
+      content: 'S';
+      color: #d6ecff;
       border: 1px solid #4a9eff;
       background-color: #2a4a7a;
       border-radius: 3px;
     }
 
-    .bb-glyph--ch-live,
-    .bb-glyph--ch-muted,
-    .bb-glyph--ch-soloed {
+    .bb-glyph--ch-mute-off,
+    .bb-glyph--ch-mute-on,
+    .bb-glyph--ch-solo-off,
+    .bb-glyph--ch-solo-on {
       cursor: pointer;
     }
   `;
@@ -177,6 +182,8 @@ export function setupGlyphMargin(
   // current position event), then falls back to a noteCount boundary walk when no
   // pattern-name match is found.
   let previewChunkInfo: Record<number, Array<{ seqName: string; noteCount: number; patNames: string[] }>> = {};
+
+  const glyphMarginLane = (monaco as any).GlyphMarginLane ?? { Left: 1, Right: 2 };
 
   // Decoration-ID bookkeeping so Monaco can diff on the next update
   let positionIds: string[] = [];
@@ -293,24 +300,32 @@ export function setupGlyphMargin(
       const info = states[chId];
       if (!info) continue;
 
-      let cls: string;
-      let hint: string;
-      if (info.soloed) {
-        cls  = 'bb-glyph--ch-soloed';
-        hint = `Channel ${chId} soloed — click to unsolo`;
-      } else if (info.muted) {
-        cls  = 'bb-glyph--ch-muted';
-        hint = `Channel ${chId} muted — click to unmute`;
-      } else {
-        cls  = 'bb-glyph--ch-live';
-        hint = `Channel ${chId} live — click to mute`;
-      }
+      const muteClass = info.muted ? 'bb-glyph--ch-mute-on' : 'bb-glyph--ch-mute-off';
+      const soloClass = info.soloed ? 'bb-glyph--ch-solo-on' : 'bb-glyph--ch-solo-off';
 
       decors.push({
         range: new monaco.Range(ln, 1, ln, 1),
         options: {
-          glyphMarginClassName: cls,
-          glyphMarginHoverMessage: { value: hint },
+          glyphMarginClassName: muteClass,
+          glyphMargin: { position: glyphMarginLane.Left },
+          glyphMarginHoverMessage: {
+            value: info.muted
+              ? `Channel ${chId} muted — click to unmute`
+              : `Channel ${chId} live — click to mute`,
+          },
+        },
+      });
+
+      decors.push({
+        range: new monaco.Range(ln, 1, ln, 1),
+        options: {
+          glyphMarginClassName: soloClass,
+          glyphMargin: { position: glyphMarginLane.Right },
+          glyphMarginHoverMessage: {
+            value: info.soloed
+              ? `Channel ${chId} soloed — click to unsolo`
+              : `Channel ${chId} not soloed — click to solo`,
+          },
         },
       });
     }
@@ -401,19 +416,30 @@ export function setupGlyphMargin(
     previewChunkInfo = chunkInfo;
   });
 
-  // ── Glyph-margin click → toggle mute or solo ─────────────────────────────
-  // Clicking the S (soloed) badge un-solos the channel.
-  // Clicking the M (muted) or ♪ (live) badge toggles mute.
+  // ── Glyph-margin click → lane-based mute/solo toggle ─────────────────────
+  // Left lane toggles Mute, right lane toggles Solo.
+
+  function getLaneFromMarginClick(target: any): 'left' | 'right' {
+    const detail = target?.detail;
+    if (!detail) return 'left';
+    const glyphMarginWidth = Number(detail.glyphMarginWidth ?? 0);
+    const glyphMarginLeft = Number(detail.glyphMarginLeft ?? 0);
+    const offsetX = Number(detail.offsetX ?? 0);
+    if (glyphMarginWidth <= 0) return 'left';
+
+    const localX = offsetX - glyphMarginLeft;
+    return localX >= glyphMarginWidth / 2 ? 'right' : 'left';
+  }
 
   const mouseDisposable = monacoEditor.onMouseDown((e: any) => {
     if (e.target.type !== (monaco.editor as any).MouseTargetType.GUTTER_GLYPH_MARGIN) return;
     const lineNumber: number | undefined = e.target.position?.lineNumber;
     if (lineNumber === undefined) return;
+    const lane = getLaneFromMarginClick(e.target);
 
     for (const [chId, ln] of channelLineMap.entries()) {
       if (ln === lineNumber) {
-        const info = channelStates.get()[chId];
-        if (info?.soloed) {
+        if (lane === 'right') {
           toggleChannelSoloed(chId);
         } else {
           toggleChannelMuted(chId);

--- a/apps/web-ui/src/main.ts
+++ b/apps/web-ui/src/main.ts
@@ -859,7 +859,6 @@ eventBus.on('playback:paused', () => {
 
 eventBus.on('playback:started',  () => { try { patternGrid.resumePositions(); } catch (_e) {} });
 eventBus.on('playback:resumed',  () => { try { patternGrid.resumePositions(); } catch (_e) {} });
-eventBus.on('playback:started',  () => { try { patternGrid.resetGlobalCursor(); } catch (_e) {} });
 
 // When a new file is loaded, clear the manual loop override so the next
 // parse:success can re-sync the loop button from the incoming song's play directive.

--- a/apps/web-ui/src/main.ts
+++ b/apps/web-ui/src/main.ts
@@ -788,7 +788,7 @@ eventBus.on('parse:success', ({ ast, song }: any) => {
     if (ast?.channels?.length) {
       ensureChannels((ast.channels as any[]).map((c: any) => c.id as number));
     }
-    if (song) patternGrid.setSong(song);
+    if (song) patternGrid.setSong(song, ast);
   } catch (_e) {}
 });
 
@@ -826,6 +826,10 @@ eventBus.on('playback:position', ({ current, total }) => {
         transportBar.flashBeatLed();
       }
     }
+
+    // Global Pattern Grid playhead follows elapsed wall-clock time.
+    const playheadProgress = total > 0 ? (current / total) : 0;
+    patternGrid.setGlobalProgress(playheadProgress);
   } catch (_e) {}
 });
 
@@ -855,6 +859,7 @@ eventBus.on('playback:paused', () => {
 
 eventBus.on('playback:started',  () => { try { patternGrid.resumePositions(); } catch (_e) {} });
 eventBus.on('playback:resumed',  () => { try { patternGrid.resumePositions(); } catch (_e) {} });
+eventBus.on('playback:started',  () => { try { patternGrid.resetGlobalCursor(); } catch (_e) {} });
 
 // When a new file is loaded, clear the manual loop override so the next
 // parse:success can re-sync the loop button from the incoming song's play directive.

--- a/apps/web-ui/src/panels/song-visualizer.ts
+++ b/apps/web-ui/src/panels/song-visualizer.ts
@@ -68,8 +68,9 @@ const BG_EFFECTS: BgEffect[] = [
       (canvas as any).__bbScanState = { beamY: 0 };
     },
     draw(canvas, rmsValues) {
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
+      const maybeCtx = canvas.getContext('2d');
+      if (!maybeCtx) return;
+      const ctx: CanvasRenderingContext2D = maybeCtx;
 
       const W = canvas.width;
       const H = canvas.height;
@@ -364,6 +365,9 @@ export class SongVisualizer {
     const titleBlock = document.createElement('div');
     titleBlock.className = 'bb-viz__title-block';
 
+    const leftCol = document.createElement('div');
+    leftCol.className = 'bb-viz__left-col';
+
     const channelTitle = document.createElement('span');
     channelTitle.className = 'bb-viz__channel-title';
     channelTitle.textContent = `Channel ${ch.id}`;
@@ -399,11 +403,6 @@ export class SongVisualizer {
     right.appendChild(patternEl);
     right.appendChild(waveCanvas);
 
-    header.appendChild(levelBar);
-    header.appendChild(titleBlock);
-    header.appendChild(right);
-    card.appendChild(header);
-
     const progressWrap = document.createElement('div');
     progressWrap.className = 'bb-viz__progress-wrap';
     const progressFill = document.createElement('div');
@@ -426,21 +425,28 @@ export class SongVisualizer {
 
     const muteBtn = document.createElement('button');
     muteBtn.type = 'button';
-    muteBtn.className = 'bb-viz__btn bb-viz__btn--mute';
+    muteBtn.className = 'bb-cp__btn bb-cp__btn--mute';
     muteBtn.id = `bb-viz-mute-${ch.id}`;
     this.applyMuteStyle(muteBtn, isMuted);
     muteBtn.addEventListener('click', () => toggleChannelMuted(ch.id));
 
     const soloBtn = document.createElement('button');
     soloBtn.type = 'button';
-    soloBtn.className = 'bb-viz__btn bb-viz__btn--solo';
+    soloBtn.className = 'bb-cp__btn bb-cp__btn--solo';
     soloBtn.id = `bb-viz-solo-${ch.id}`;
     this.applySoloStyle(soloBtn, isSoloed);
     soloBtn.addEventListener('click', () => toggleChannelSoloed(ch.id));
 
     ctrlRow.appendChild(muteBtn);
     ctrlRow.appendChild(soloBtn);
-    card.appendChild(ctrlRow);
+
+    leftCol.appendChild(titleBlock);
+    leftCol.appendChild(ctrlRow);
+
+    header.appendChild(levelBar);
+    header.appendChild(leftCol);
+    header.appendChild(right);
+    card.appendChild(header);
 
     return card;
   }
@@ -685,19 +691,17 @@ export class SongVisualizer {
   }
 
   private applyMuteStyle(btn: HTMLButtonElement, muted: boolean): void {
-    btn.innerHTML = muted
-      ? icon('speaker-x-mark', 'w-3.5 h-3.5')
-      : icon('speaker-wave', 'w-3.5 h-3.5');
+    btn.textContent = 'M';
     btn.title = muted ? 'Unmute channel' : 'Mute channel';
     btn.setAttribute('aria-pressed', String(muted));
-    btn.classList.toggle('bb-viz__btn--active', muted);
+    btn.classList.toggle('bb-cp__btn--active', muted);
   }
 
   private applySoloStyle(btn: HTMLButtonElement, soloed: boolean): void {
-    btn.innerHTML = icon('eye', 'w-3.5 h-3.5');
+    btn.textContent = 'S';
     btn.title = soloed ? 'Remove solo' : 'Solo this channel';
     btn.setAttribute('aria-pressed', String(soloed));
-    btn.classList.toggle('bb-viz__btn--active', soloed);
+    btn.classList.toggle('bb-cp__btn--active', soloed);
   }
 
   private getInstrumentName(ch: any): string {

--- a/apps/web-ui/src/playback/playback-manager.ts
+++ b/apps/web-ui/src/playback/playback-manager.ts
@@ -80,6 +80,8 @@ export class PlaybackManager {
   private _loop = false;
   private _bpmOverride: number | null = null;
   private _masterAnalyser: AnalyserNode | null = null;
+  /** Periodic timer for elapsed-time playback:position updates. */
+  private _positionTimer: ReturnType<typeof setInterval> | null = null;
   // Track playback position per channel
   private playbackPosition: Map<number, PlaybackPosition> = new Map();
   private channelEvents: Map<number, any[]> = new Map(); // channelId → full event array
@@ -357,6 +359,8 @@ export class PlaybackManager {
           // Start the next iteration first so the Player can apply the effective
           // master volume (user override or AST volume) before we emit the UI message.
           this.player!.playAST(resolved as any).then(() => {
+            this._startPositionTimer(this.player!);
+            this._emitElapsedPosition(this.player!);
             try {
               const gain = this.player!.getMasterGain();
               const resolvedVol = this._pendingMasterVolume !== null ? this._pendingMasterVolume : (gain ? (gain.gain.value ?? 1) : 1);
@@ -440,6 +444,8 @@ export class PlaybackManager {
       }
       await this.player.playAST(resolved as any);
       log.debug('player.playAST() completed');
+      this._startPositionTimer(this.player);
+      this._emitElapsedPosition(this.player);
 
       // Update state
       this.state.isPlaying = true;
@@ -475,6 +481,7 @@ export class PlaybackManager {
     if (!this.player) return;
 
     try {
+      this._stopPositionTimer();
       if (typeof this.player.stop === 'function') {
         this.player.stop();
       }
@@ -735,35 +742,58 @@ export class PlaybackManager {
       log.debug(`Emitting playback:position-changed for channel ${channelId}`, position);
       this.eventBus.emit('playback:position-changed', { channelId, position });
 
-      // Also emit a legacy-style time position event (seconds) so UI
-      // components that expect `playback:position` (e.g. StatusBar,
-      // TransportBar) continue to receive elapsed time updates.
-      try {
-        const playerAny: any = player as any;
-        const startTs = playerAny._playbackStartTimestamp || 0;
-        const pauseTs = playerAny._pauseTimestamp || 0;
-        const completionMs = playerAny._completionTimeoutMs || 0;
-        let currentSec = 0;
-        let totalSec = 0;
-
-        if (startTs) {
-          // If paused, _pauseTimestamp contains the timestamp when paused;
-          // subtract pause time if present. Keep a simple approximation.
-          const now = Date.now();
-          const pausedOffset = pauseTs && pauseTs > startTs ? (now - pauseTs) : 0;
-          currentSec = Math.max(0, (now - startTs - pausedOffset) / 1000);
-        }
-
-        if (completionMs) totalSec = completionMs / 1000;
-
-        this.eventBus.emit('playback:position', { current: currentSec, total: totalSec });
-        playbackPositionAtom.set(currentSec);
-        playbackDuration.set(totalSec);
-        playbackTimeLabel.set(formatPlaybackTime(currentSec));
-      } catch (e) {
-        // Non-fatal - don't break playback if timing inference fails
-      }
+      // Elapsed-time updates are emitted by the periodic position timer.
     };
+  }
+
+  private _startPositionTimer(player: Player): void {
+    this._stopPositionTimer();
+    this._positionTimer = setInterval(() => this._emitElapsedPosition(player), 33);
+  }
+
+  private _stopPositionTimer(): void {
+    if (!this._positionTimer) return;
+    clearInterval(this._positionTimer);
+    this._positionTimer = null;
+  }
+
+  private _emitElapsedPosition(player: Player): void {
+    try {
+      const playerAny: any = player as any;
+      const startTs = playerAny._playbackStartTimestamp || 0;
+      const pauseTs = playerAny._pauseTimestamp || 0;
+      const completionMs = playerAny._completionTimeoutMs || 0;
+      const isRepeatMode = !!playerAny._isRepeatMode;
+      let currentSec = 0;
+      let totalSec = 0;
+
+      if (startTs) {
+        // If paused, keep elapsed time frozen at pause point.
+        const now = Date.now();
+        const pausedOffset = pauseTs && pauseTs > startTs ? (now - pauseTs) : 0;
+        currentSec = Math.max(0, (now - startTs - pausedOffset) / 1000);
+      }
+
+      if (completionMs) totalSec = completionMs / 1000;
+
+      // Engine repeat mode keeps a stable start timestamp across iterations.
+      // Wrap elapsed time by loop duration so UI progress returns to 0 exactly
+      // at each real loop boundary (not at pre-schedule callback time).
+      if (totalSec > 0) {
+        if (isRepeatMode) {
+          currentSec = ((currentSec % totalSec) + totalSec) % totalSec;
+        } else {
+          currentSec = Math.min(currentSec, totalSec);
+        }
+      }
+
+      this.eventBus.emit('playback:position', { current: currentSec, total: totalSec });
+      playbackPositionAtom.set(currentSec);
+      playbackDuration.set(totalSec);
+      playbackTimeLabel.set(formatPlaybackTime(currentSec));
+    } catch {
+      // Non-fatal: elapsed-time display should never break playback.
+    }
   }
 
   /**

--- a/apps/web-ui/src/stores/channel.store.ts
+++ b/apps/web-ui/src/stores/channel.store.ts
@@ -74,12 +74,22 @@ channelStates.subscribe((states) => {
 
 export function setChannelMuted(id: number, muted: boolean): void {
   const current = channelStates.get();
-  channelStates.setKey(id, { ...current[id], muted });
+  channelStates.setKey(id, {
+    ...current[id],
+    muted,
+    // A muted channel cannot stay soloed.
+    soloed: muted ? false : current[id].soloed,
+  });
 }
 
 export function setChannelSoloed(id: number, soloed: boolean): void {
   const current = channelStates.get();
-  channelStates.setKey(id, { ...current[id], soloed });
+  channelStates.setKey(id, {
+    ...current[id],
+    soloed,
+    // A soloed channel must be audible.
+    muted: soloed ? false : current[id].muted,
+  });
 }
 
 export function setChannelVolume(id: number, volume: number): void {
@@ -111,9 +121,16 @@ export function toggleChannelSoloed(id: number): void {
   if (wasSoloed) {
     setChannelSoloed(id, false);
   } else {
-    // Solo this channel, unsolo all others
-    for (const chId of Object.keys(current).map(Number)) {
-      setChannelSoloed(chId, chId === id);
+    // Solo this channel, unsolo all others.
+    // Soloing implies audibility, so the selected channel is auto-unmuted.
+    const latest = channelStates.get();
+    for (const chId of Object.keys(latest).map(Number)) {
+      const info = latest[chId];
+      channelStates.setKey(chId, {
+        ...info,
+        soloed: chId === id,
+        muted: chId === id ? false : info.muted,
+      });
     }
   }
 }

--- a/apps/web-ui/src/stores/channel.store.ts
+++ b/apps/web-ui/src/stores/channel.store.ts
@@ -74,21 +74,23 @@ channelStates.subscribe((states) => {
 
 export function setChannelMuted(id: number, muted: boolean): void {
   const current = channelStates.get();
+  const base = current[id] ?? makeDefaultChannel(id);
   channelStates.setKey(id, {
-    ...current[id],
+    ...base,
     muted,
     // A muted channel cannot stay soloed.
-    soloed: muted ? false : current[id].soloed,
+    soloed: muted ? false : base.soloed,
   });
 }
 
 export function setChannelSoloed(id: number, soloed: boolean): void {
   const current = channelStates.get();
+  const base = current[id] ?? makeDefaultChannel(id);
   channelStates.setKey(id, {
-    ...current[id],
+    ...base,
     soloed,
     // A soloed channel must be audible.
-    muted: soloed ? false : current[id].muted,
+    muted: soloed ? false : base.muted,
   });
 }
 

--- a/apps/web-ui/src/styles.css
+++ b/apps/web-ui/src/styles.css
@@ -1823,6 +1823,13 @@
   height: 16px;
 }
 
+.bb-pgrid__rows {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
 /* Coloured channel-identity dot */
 .bb-pgrid__dot {
   width: 7px;
@@ -1837,26 +1844,54 @@
   height: 100%;
   position: relative;
   display: flex;
-  /* no gap — blocks use flex-grow so they fill exactly to align across channels */
+  gap: 1px;
   border-radius: 2px;
   overflow: hidden;
   background: rgba(255,255,255,0.03);
 }
 
 .bb-pgrid__block {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: 100%;
   /* flex-grow is set inline; flex-shrink/basis left at defaults */
   min-width: 0;
-  border-radius: 1px;
+  border-radius: 2px;
+  border: 1px solid rgba(255,255,255,0.18);
+  box-sizing: border-box;
   transition: filter 0.08s;
   cursor: default;
+  padding: 0 3px;
 }
 .bb-pgrid__block--filler {
   /* transparent tail-filler for channels shorter than the longest channel */
-  background: transparent !important;
+  background: transparent;
+  border: none;
+  pointer-events: none;
+}
+.bb-pgrid__block--tail {
   pointer-events: none;
 }
 .bb-pgrid__block:not(.bb-pgrid__block--filler):hover { filter: brightness(1.8); }
+
+.bb-pgrid__block-label {
+  font-size: 8px;
+  line-height: 1;
+  font-weight: 600;
+  color: rgba(255,255,255,0.90);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  pointer-events: none;
+}
+
+/* Hide labels in very narrow chips to avoid unreadable clutter. */
+.bb-pgrid__block--compact .bb-pgrid__block-label {
+  display: none;
+}
 
 /* Live playback cursor — thin vertical line */
 .bb-pgrid__cursor {
@@ -1870,7 +1905,24 @@
   pointer-events: none;
   z-index: 2;
   transform: translateX(-1px);
-  transition: opacity 0.15s;
+  transition: opacity 0.15s, left 0.07s linear;
+}
+
+/* Primary DAW-style playhead spanning all rows. */
+.bb-pgrid__cursor--global {
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  width: 2px;
+  background: rgba(255,255,255,0.98);
+  box-shadow: 0 0 8px rgba(255,255,255,0.65);
+}
+
+/* Secondary per-channel cursors remain visible but de-emphasized. */
+.bb-pgrid__cursor--channel {
+  opacity: 0.30;
+  width: 1px;
+  box-shadow: none;
 }
 /* Paused state — cursor stays visible but dimmed */
 .bb-pgrid__cursor--paused {
@@ -1927,7 +1979,11 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.15);
 }
 [data-theme=light] .bb-pgrid__track { background: rgba(0,0,0,0.06); }
+[data-theme=light] .bb-pgrid__block { border-color: rgba(0,0,0,0.18); }
+[data-theme=light] .bb-pgrid__block-label { color: rgba(0,0,0,0.82); text-shadow: none; }
 [data-theme=light] .bb-pgrid__cursor { background: rgba(0,0,0,0.80); box-shadow: none; }
+[data-theme=light] .bb-pgrid__cursor--global { background: rgba(0,0,0,0.90); }
+[data-theme=light] .bb-pgrid__cursor--channel { background: rgba(0,0,0,0.45); opacity: 0.35; }
 [data-theme=light] .bb-pgrid__btn {
   border-color: rgba(0,0,0,0.18);
   background: rgba(0,0,0,0.06);
@@ -2110,15 +2166,17 @@
 }
 [data-theme="light"] .bb-menu-bar__logo { filter: invert(1) hue-rotate(180deg) brightness(0.7); }
 .bb-menu-bar__song-name {
-  margin-left: auto;
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
   padding: 0 12px;
-  align-self: center;
+  top: 50%;
   font-size: 12px;
   color: #888;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 260px;
+  max-width: min(50vw, 420px);
   pointer-events: none;
   user-select: none;
   font-style: italic;
@@ -2242,7 +2300,15 @@
 .bb-viz__card[data-channel="3"] { border-top: 3px solid var(--bb-ch3); }
 .bb-viz__card[data-channel="4"] { border-top: 3px solid var(--bb-ch4); }
 
-.bb-viz__card-header { display: flex; gap: 8px; align-items: flex-start; }
+.bb-viz__card-header { display: flex; gap: 8px; align-items: stretch; }
+
+.bb-viz__left-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 4px;
+  min-width: 68px;
+}
 
 /* Level bar: vertical VU strip */
 .bb-viz__level-bar {
@@ -2255,7 +2321,7 @@
 }
 
 /* Title block */
-.bb-viz__title-block { display: flex; flex-direction: column; gap: 2px; min-width: 68px; }
+.bb-viz__title-block { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 
 .bb-viz__channel-title {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -2323,7 +2389,7 @@
 .bb-viz__progress-wrap { height: 3px; background: #0e1e0e; border-radius: 2px; overflow: hidden; }
 .bb-viz__progress-fill { height: 100%; width: 0; background: #3dff70; box-shadow: 0 0 4px rgba(61,255,112,0.60); transition: width 0.1s linear; }
 .bb-viz__position { font-size: 10px; color: #555; }
-.bb-viz__ctrl-row { display: flex; gap: 4px; }
+.bb-viz__ctrl-row { display: flex; gap: 4px; margin-top: auto; align-items: flex-end; }
 
 /* 3-D raised buttons — matches transport bar style */
 .bb-viz__btn {
@@ -3707,15 +3773,17 @@
 }
 [data-theme="light"] .bb-menu-bar__logo { filter: invert(1) hue-rotate(180deg) brightness(0.7); }
 .bb-menu-bar__song-name {
-  margin-left: auto;
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
   padding: 0 12px;
-  align-self: center;
+  top: 50%;
   font-size: 12px;
   color: #888;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 260px;
+  max-width: min(50vw, 420px);
   pointer-events: none;
   user-select: none;
 }
@@ -3838,7 +3906,15 @@
 .bb-viz__card[data-channel="3"] { border-top: 3px solid var(--bb-ch3); }
 .bb-viz__card[data-channel="4"] { border-top: 3px solid var(--bb-ch4); }
 
-.bb-viz__card-header { display: flex; gap: 8px; align-items: flex-start; }
+.bb-viz__card-header { display: flex; gap: 8px; align-items: stretch; }
+
+.bb-viz__left-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 4px;
+  min-width: 68px;
+}
 
 /* Level bar: vertical VU strip */
 .bb-viz__level-bar {
@@ -3851,7 +3927,7 @@
 }
 
 /* Title block */
-.bb-viz__title-block { display: flex; flex-direction: column; gap: 2px; min-width: 68px; }
+.bb-viz__title-block { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 
 .bb-viz__channel-title {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -3919,7 +3995,7 @@
 .bb-viz__progress-wrap { height: 3px; background: #0e1e0e; border-radius: 2px; overflow: hidden; }
 .bb-viz__progress-fill { height: 100%; width: 0; background: #3dff70; box-shadow: 0 0 4px rgba(61,255,112,0.60); transition: width 0.1s linear; }
 .bb-viz__position { font-size: 10px; color: #555; }
-.bb-viz__ctrl-row { display: flex; gap: 4px; }
+.bb-viz__ctrl-row { display: flex; gap: 4px; margin-top: auto; align-items: flex-end; }
 
 /* 3-D raised buttons — matches transport bar style */
 .bb-viz__btn {

--- a/apps/web-ui/src/ui/menu-bar.ts
+++ b/apps/web-ui/src/ui/menu-bar.ts
@@ -247,7 +247,7 @@ export class MenuBar {
     this.el.appendChild(this.buildMenu('view', 'View', this.viewItems()));
     this.el.appendChild(this.buildMenu('help', 'Help', this.helpItems()));
 
-    // ── Song name — right-aligned in the remaining menu bar space ──────────
+    // ── Song name — centered in the menu bar ───────────────────────────────
     this.songNameEl = document.createElement('span');
     this.songNameEl.className = 'bb-menu-bar__song-name';
     this.songNameEl.textContent = 'untitled';

--- a/apps/web-ui/src/ui/pattern-grid.ts
+++ b/apps/web-ui/src/ui/pattern-grid.ts
@@ -9,7 +9,8 @@
  *   const grid = new PatternGrid();
  *   container.appendChild(grid.el);
  *   grid.setSong(song);                                  // on parse:success (SongModel)
- *   grid.setPosition(channelId, position.progress);      // on playback:position-changed
+ *   grid.setPosition(channelId, position.progress);      // per-channel cursor
+ *   grid.setGlobalProgress(playbackProgress);            // on playback:position
  *   grid.pausePositions();                               // on playback:paused
  *   grid.resumePositions();                              // on playback:resumed / started
  *   grid.clearPositions();                               // on playback:stopped
@@ -29,13 +30,50 @@ function hexToRgba(hex: string, alpha: number): string {
   return `rgba(${r},${g},${b},${alpha})`;
 }
 
+function hashPatternName(name: string): number {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) {
+    h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
 interface Segment {
   patName: string;
   seqName: string | null;
   count: number;
 }
 
-function buildSegments(events: any[]): Segment[] {
+interface RowBuildData {
+  ch: any;
+  segs: Segment[];
+  displayTotal: number;
+}
+
+function abbreviatePatternName(name: string, maxLen = 9): string {
+  if (name.length <= maxLen) return name;
+  const keepHead = Math.max(3, Math.floor((maxLen - 1) / 2));
+  const keepTail = Math.max(2, maxLen - keepHead - 1);
+  return `${name.slice(0, keepHead)}…${name.slice(-keepTail)}`;
+}
+
+function parseRepeatSpec(token: string): { base: string; repeat: number } {
+  const t = token.trim();
+  const rep = t.match(/^(.+?)\s*\*\s*(\d+)$/);
+  if (!rep) return { base: t, repeat: 1 };
+  const repeat = Math.max(1, parseInt(rep[2], 10) || 1);
+  return { base: rep[1].trim(), repeat };
+}
+
+function tokenToPatternName(token: string): string {
+  const t = token.trim();
+  if (!t) return '';
+  // Strip repetition suffix and transform/effect suffixes, keep the base ref.
+  const { base } = parseRepeatSpec(t);
+  return base.split(':')[0].trim();
+}
+
+function buildSegmentsFromEvents(events: any[]): Segment[] {
   const segs: Segment[] = [];
   let cur: Segment | null = null;
   for (const ev of events) {
@@ -43,7 +81,7 @@ function buildSegments(events: any[]): Segment[] {
     const prevSeq: string | null = cur ? cur.seqName : null;
     const pat: string = ev.sourcePattern ?? prevPat;
     const seq: string | null = ev.sourceSequence ?? prevSeq;
-    if (!cur || pat !== cur.patName) {
+    if (!cur || pat !== cur.patName || seq !== cur.seqName) {
       cur = { patName: pat, seqName: seq, count: 1 };
       segs.push(cur);
     } else {
@@ -51,6 +89,101 @@ function buildSegments(events: any[]): Segment[] {
     }
   }
   return segs;
+}
+
+function buildSegmentsFromSequence(seqName: string, seqTokens: string[], pats: Record<string, string[]>): Segment[] {
+  const segs: Segment[] = [];
+  for (const raw of seqTokens) {
+    if (typeof raw !== 'string') continue;
+    const token = raw.trim();
+    if (!token) continue;
+
+    // Expand simple inline repetition syntax, e.g. "mel_a1 * 2".
+    const rep = token.match(/^(.+?)\s*\*\s*(\d+)$/);
+    const repeat = rep ? Math.max(1, parseInt(rep[2], 10) || 1) : 1;
+    const ref = rep ? rep[1] : token;
+    const patName = tokenToPatternName(ref);
+    if (!patName) continue;
+    const patLen = Array.isArray(pats[patName]) ? pats[patName].length : 1;
+
+    for (let i = 0; i < repeat; i++) {
+      segs.push({ patName, seqName, count: Math.max(1, patLen) });
+    }
+  }
+  return segs;
+}
+
+function getAstChannelSpecTokens(astChannel: any): string[] {
+  const seqSpec: string[] | undefined = (astChannel as any)?.seqSpecTokens;
+  if (Array.isArray(seqSpec) && seqSpec.length > 0) {
+    return seqSpec.map((s) => String(s)).map((s) => s.trim()).filter(Boolean);
+  }
+  if (typeof astChannel?.seq === 'string' && astChannel.seq.trim()) {
+    return astChannel.seq.split(/\s*,\s*|\s+/).map((s: string) => s.trim()).filter(Boolean);
+  }
+  if (typeof astChannel?.pat === 'string' && astChannel.pat.trim()) {
+    return astChannel.pat.split(/\s*,\s*|\s+/).map((s: string) => s.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function expandRefToPatternSegments(
+  refToken: string,
+  astSeqs: Record<string, any>,
+  pats: Record<string, string[]>,
+  rootSeqName: string | null,
+  out: Segment[],
+  visiting: Set<string>
+): void {
+  const { base, repeat } = parseRepeatSpec(refToken);
+  const refName = tokenToPatternName(base);
+  if (!refName) return;
+
+  const seqItems = astSeqs?.[refName];
+  if (Array.isArray(seqItems)) {
+    if (visiting.has(refName)) return;
+    visiting.add(refName);
+    for (let r = 0; r < repeat; r++) {
+      for (const item of seqItems) {
+        const inner = typeof item === 'string'
+          ? item
+          : String((item as any)?.raw ?? (item as any)?.name ?? (item as any)?.pattern ?? (item as any)?.ref ?? '');
+        if (!inner.trim()) continue;
+        const itemRepeat = typeof item === 'object' && item !== null
+          ? Math.max(1, Number((item as any).repeat) || 1)
+          : 1;
+        for (let ir = 0; ir < itemRepeat; ir++) {
+          expandRefToPatternSegments(inner, astSeqs, pats, rootSeqName ?? refName, out, visiting);
+        }
+      }
+    }
+    visiting.delete(refName);
+    return;
+  }
+
+  const patLen = Array.isArray(pats[refName]) ? pats[refName].length : 1;
+  for (let r = 0; r < repeat; r++) {
+    out.push({ patName: refName, seqName: rootSeqName, count: Math.max(1, patLen) });
+  }
+}
+
+function buildSegmentsFromAstChannel(astChannel: any, ast: any, pats: Record<string, string[]>): Segment[] {
+  const tokens = getAstChannelSpecTokens(astChannel);
+  if (tokens.length === 0) return [];
+
+  const segs: Segment[] = [];
+  const astSeqs: Record<string, any> = ast?.seqs ?? {};
+  for (const token of tokens) {
+    const refName = tokenToPatternName(token);
+    const rootSeqName = Array.isArray(astSeqs[refName]) ? refName : null;
+    expandRefToPatternSegments(token, astSeqs, pats, rootSeqName, segs, new Set<string>());
+  }
+  return segs;
+}
+
+function getSegmentDisplayUnits(seg: Segment, pats: Record<string, string[]>): number {
+  const patLen = Array.isArray(pats[seg.patName]) ? pats[seg.patName].length : 0;
+  return patLen > 0 ? patLen : seg.count;
 }
 
 interface RowMeta {
@@ -72,12 +205,14 @@ export class PatternGrid {
   onNavigate?: (patName: string) => void;
 
   private _rows             = new Map<number, RowMeta>();
-  /** Note-only event count per channel, stored to normalize cursor progress. */
-  private _noteTotals       = new Map<number, number>();
-  /** Max note count across all channels — used to scale cursors to wall-clock time. */
-  private _globalNoteTotal  = 1;
   /** Max total events (note + rest) across all channels — used as block-width denominator. */
   private _globalEventTotal = 1;
+  /** Single DAW-style playhead spanning the full grid. */
+  private _globalCursor: HTMLElement | null = null;
+  /** Wrapper around all rows; provides global cursor coordinate space. */
+  private _rowsWrap: HTMLElement | null = null;
+  /** Last global cursor percentage. */
+  private _globalPct = 0;
   /** Unsubscribe from channelStates store. */
   private _unsubStore: (() => void) | null = null;
 
@@ -94,10 +229,12 @@ export class PatternGrid {
   }
 
   /** Rebuild the grid from a resolved SongModel (treated as `any` to avoid import deps). */
-  setSong(song: any): void {
+  setSong(song: any, ast?: any): void {
     this.el.innerHTML = '';
     this._rows.clear();
-    this._noteTotals.clear();
+    this._globalCursor = null;
+    this._rowsWrap = null;
+    this._globalPct = 0;
 
     const channels: any[] = song?.channels ?? [];
     if (channels.length === 0) {
@@ -106,26 +243,45 @@ export class PatternGrid {
     }
     delete this.el.dataset['empty'];
 
-    // ── First pass: compute global totals for cross-channel alignment ────────
-    let maxEvents = 1;
-    let maxNotes  = 1;
-    for (const ch of channels) {
+    const rowsWrap = document.createElement('div');
+    rowsWrap.className = 'bb-pgrid__rows';
+    this._rowsWrap = rowsWrap;
+
+    const globalCursor = document.createElement('div');
+    globalCursor.className = 'bb-pgrid__cursor bb-pgrid__cursor--global';
+    globalCursor.setAttribute('aria-hidden', 'true');
+    globalCursor.style.display = 'none';
+    rowsWrap.appendChild(globalCursor);
+    this._globalCursor = globalCursor;
+
+    const pats: Record<string, string[]> = song?.pats ?? {};
+    const rowData: RowBuildData[] = channels.map((ch) => {
       const events: any[] = ch.events ?? [];
-      const noteCount = events.filter((e: any) => e.type === 'note' || e.type === 'named').length;
-      this._noteTotals.set(ch.id ?? 0, noteCount || 1);
-      if (events.length > maxEvents) maxEvents = events.length;
-      if (noteCount  > maxNotes)  maxNotes  = noteCount;
+      const astChannel = (ast?.channels ?? []).find((c: any) => (c?.id ?? 0) === (ch?.id ?? 0));
+      const astSegs = astChannel ? buildSegmentsFromAstChannel(astChannel, ast, pats) : [];
+      const segs = astSegs.length > 0 ? astSegs : buildSegmentsFromEvents(events);
+      const displayTotal = Math.max(1, segs.reduce((acc, seg) => acc + getSegmentDisplayUnits(seg, pats), 0));
+      return {
+        ch,
+        segs,
+        displayTotal,
+      };
+    });
+
+    // ── First pass: compute global totals for cross-channel alignment ────────
+    let maxUnits = 1;
+    for (const row of rowData) {
+      if (row.displayTotal > maxUnits) maxUnits = row.displayTotal;
     }
-    this._globalEventTotal = maxEvents;
-    this._globalNoteTotal  = maxNotes;
+    this._globalEventTotal = maxUnits;
 
     // ── Second pass: build rows ───────────────────────────────────────────────
     const chip: string = song?.chip ?? 'gameboy';
-    for (const ch of channels) {
+    for (const rowInfo of rowData) {
+      const ch = rowInfo.ch;
       const channelId: number = ch.id ?? 0;
       const color = getChannelColor(chip, channelId);
-      const events: any[] = ch.events ?? [];
-      const segs = buildSegments(events);
+      const segs = rowInfo.segs;
 
       // ── Row ──────────────────────────────────────────────────────────────
       const row = document.createElement('div');
@@ -172,20 +328,38 @@ export class PatternGrid {
       // Track strip (blocks + cursor)
       const track = document.createElement('div');
       track.className = 'bb-pgrid__track';
+      const patternToneByName = new Map<string, number>();
+      const toneLevels = [0.80, 0.64, 0.48, 0.32];
 
-      const channelTotal = events.length;
+      const channelTotal = rowInfo.displayTotal;
 
-      let segIdx = 0;
       for (const seg of segs) {
         const block = document.createElement('div');
         block.className = 'bb-pgrid__block';
-        block.style.flexGrow = String(seg.count);
-        block.style.background = hexToRgba(color, segIdx % 2 === 0 ? 0.55 : 0.30);
+        const displayUnits = getSegmentDisplayUnits(seg, pats);
+        if (displayUnits <= 1) block.classList.add('bb-pgrid__block--compact');
+        block.style.flex = `${displayUnits} 1 0%`;
+        let tone = patternToneByName.get(seg.patName);
+        if (tone === undefined) {
+          tone = toneLevels[hashPatternName(seg.patName) % toneLevels.length];
+          patternToneByName.set(seg.patName, tone);
+        }
+        block.style.background = hexToRgba(color, tone);
+        block.style.borderColor = hexToRgba(color, Math.min(0.95, tone + 0.18));
         const blockLabel = seg.seqName ? `${seg.seqName} › ${seg.patName}` : seg.patName;
+        const chipLabel = abbreviatePatternName(seg.patName);
         block.title = blockLabel;
         block.setAttribute('role', 'button');
         block.setAttribute('tabindex', '0');
         block.setAttribute('aria-label', `Navigate to pattern: ${blockLabel}`);
+        block.dataset['label'] = chipLabel;
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'bb-pgrid__block-label';
+        labelEl.textContent = chipLabel;
+        labelEl.setAttribute('aria-hidden', 'true');
+        block.appendChild(labelEl);
+
         // Click or Enter/Space → navigate editor to the pat definition
         const patName = seg.patName;
         block.addEventListener('click', () => this.onNavigate?.(patName));
@@ -197,7 +371,6 @@ export class PatternGrid {
         });
         block.style.cursor = 'pointer';
         track.appendChild(block);
-        segIdx++;
       }
 
       // Transparent filler block for the unused tail (if channel is shorter)
@@ -205,43 +378,50 @@ export class PatternGrid {
       if (tailEvents > 0) {
         const filler = document.createElement('div');
         filler.className = 'bb-pgrid__block bb-pgrid__block--filler';
-        filler.style.flexGrow = String(tailEvents);
+        filler.style.flex = `${tailEvents} 1 0%`;
         track.appendChild(filler);
       }
 
       // Playback cursor line (decorative)
       const cursor = document.createElement('div');
-      cursor.className = 'bb-pgrid__cursor';
+      cursor.className = 'bb-pgrid__cursor bb-pgrid__cursor--channel';
       cursor.setAttribute('aria-hidden', 'true');
       cursor.style.display = 'none';
       track.appendChild(cursor);
 
       row.appendChild(track);
-      this.el.appendChild(row);
+      rowsWrap.appendChild(row);
       this._rows.set(channelId, { track, cursor, muteBtn, soloBtn });
     }
+
+    this.el.appendChild(rowsWrap);
 
     // Apply current mute/solo state to the freshly built buttons
     this._syncMuteSolo();
   }
 
-  /**
-   * Move the cursor for a channel. `progress` is 0.0 – 1.0 from
-   * `PlaybackPosition.progress` (note eventIndex / note totalEvents).
-   *
-   * Normalised to the global note maximum so cursors across all channels
-   * advance at the same rate (wall-clock aligned).
-   */
+  /** Move the cursor for a channel. `progress` is 0.0 – 1.0. */
   setPosition(channelId: number, progress: number): void {
     const row = this._rows.get(channelId);
     if (!row) return;
-    const chNoteTotal = this._noteTotals.get(channelId) ?? 1;
-    const rawNoteIndex = progress * chNoteTotal;
-    const globalProgress = rawNoteIndex / this._globalNoteTotal;
-    const pct = Math.min(99.5, Math.max(0, globalProgress * 100));
+    const pct = Math.min(99.5, Math.max(0, progress * 100));
     row.cursor.style.display = 'block';
     row.cursor.classList.remove('bb-pgrid__cursor--paused');
     row.cursor.style.left = `${pct}%`;
+  }
+
+  /** Move the global playhead from elapsed-time progress (0.0 – 1.0). */
+  setGlobalProgress(progress: number): void {
+    const pct = Math.min(99.5, Math.max(0, progress * 100));
+    this._setGlobalCursorPosition(pct);
+  }
+
+  /** Reset only the global playhead (used on loop boundaries). */
+  resetGlobalCursor(): void {
+    this._globalPct = 0;
+    if (!this._globalCursor) return;
+    this._globalCursor.style.display = 'none';
+    this._globalCursor.classList.remove('bb-pgrid__cursor--paused');
   }
 
   /**
@@ -254,6 +434,9 @@ export class PatternGrid {
         cursor.classList.add('bb-pgrid__cursor--paused');
       }
     }
+    if (this._globalCursor && this._globalCursor.style.display !== 'none') {
+      this._globalCursor.classList.add('bb-pgrid__cursor--paused');
+    }
   }
 
   /** Remove paused dimming — call when playback resumes. */
@@ -261,6 +444,7 @@ export class PatternGrid {
     for (const { cursor } of this._rows.values()) {
       cursor.classList.remove('bb-pgrid__cursor--paused');
     }
+    this._globalCursor?.classList.remove('bb-pgrid__cursor--paused');
   }
 
   /** Hide all cursors and clear paused state. Call on playback:stopped. */
@@ -269,9 +453,37 @@ export class PatternGrid {
       cursor.style.display = 'none';
       cursor.classList.remove('bb-pgrid__cursor--paused');
     }
+    if (this._globalCursor) {
+      this._globalCursor.style.display = 'none';
+      this._globalCursor.classList.remove('bb-pgrid__cursor--paused');
+    }
+    this._globalPct = 0;
   }
 
   // ── Private ─────────────────────────────────────────────────────────────────
+
+  private _setGlobalCursorPosition(pct: number): void {
+    const global = this._globalCursor;
+    const rowsWrap = this._rowsWrap;
+    const firstRow = this._rows.values().next().value as RowMeta | undefined;
+    if (!global || !rowsWrap || !firstRow) return;
+
+    global.style.display = 'block';
+    global.classList.remove('bb-pgrid__cursor--paused');
+    this._globalPct = pct;
+
+    // Anchor to the track start (not full row start) so x=0 aligns to the
+    // first pattern block instead of the M/S controls.
+    const wrapRect = rowsWrap.getBoundingClientRect();
+    const trackRect = firstRow.track.getBoundingClientRect();
+    if (wrapRect.width <= 0 || trackRect.width <= 0) {
+      global.style.left = `${pct}%`;
+      return;
+    }
+
+    const x = (trackRect.left - wrapRect.left) + trackRect.width * (pct / 100);
+    global.style.left = `${x}px`;
+  }
 
   private _syncMuteSolo(): void {
     const states = channelStates.get();

--- a/apps/web-ui/src/ui/pattern-grid.ts
+++ b/apps/web-ui/src/ui/pattern-grid.ts
@@ -213,6 +213,13 @@ export class PatternGrid {
   private _rowsWrap: HTMLElement | null = null;
   /** Last global cursor percentage. */
   private _globalPct = 0;
+  /** Cached geometry for placing the global playhead without per-tick reflow reads. */
+  private _globalCursorXOffset = 0;
+  private _globalCursorTrackWidth = 0;
+  private _globalCursorLayoutValid = false;
+  /** Layout observers/listeners used to invalidate cached cursor geometry. */
+  private _layoutObserver: ResizeObserver | null = null;
+  private _onWindowResize = () => this._invalidateGlobalCursorLayout();
   /** Unsubscribe from channelStates store. */
   private _unsubStore: (() => void) | null = null;
 
@@ -226,15 +233,20 @@ export class PatternGrid {
 
     // Reactively update M/S button states when channel store changes
     this._unsubStore = channelStates.subscribe(() => this._syncMuteSolo());
+
+    // Recompute global cursor anchoring only when layout may have changed.
+    window.addEventListener('resize', this._onWindowResize);
   }
 
   /** Rebuild the grid from a resolved SongModel (treated as `any` to avoid import deps). */
   setSong(song: any, ast?: any): void {
+    this._teardownLayoutObserver();
     this.el.innerHTML = '';
     this._rows.clear();
     this._globalCursor = null;
     this._rowsWrap = null;
     this._globalPct = 0;
+    this._invalidateGlobalCursorLayout();
 
     const channels: any[] = song?.channels ?? [];
     if (channels.length === 0) {
@@ -395,6 +407,7 @@ export class PatternGrid {
     }
 
     this.el.appendChild(rowsWrap);
+    this._setupLayoutObserver();
 
     // Apply current mute/solo state to the freshly built buttons
     this._syncMuteSolo();
@@ -464,25 +477,60 @@ export class PatternGrid {
 
   private _setGlobalCursorPosition(pct: number): void {
     const global = this._globalCursor;
-    const rowsWrap = this._rowsWrap;
-    const firstRow = this._rows.values().next().value as RowMeta | undefined;
-    if (!global || !rowsWrap || !firstRow) return;
+    if (!global) return;
 
     global.style.display = 'block';
     global.classList.remove('bb-pgrid__cursor--paused');
     this._globalPct = pct;
 
-    // Anchor to the track start (not full row start) so x=0 aligns to the
-    // first pattern block instead of the M/S controls.
-    const wrapRect = rowsWrap.getBoundingClientRect();
-    const trackRect = firstRow.track.getBoundingClientRect();
-    if (wrapRect.width <= 0 || trackRect.width <= 0) {
+    if (!this._ensureGlobalCursorLayout()) {
       global.style.left = `${pct}%`;
       return;
     }
 
-    const x = (trackRect.left - wrapRect.left) + trackRect.width * (pct / 100);
+    const x = this._globalCursorXOffset + this._globalCursorTrackWidth * (pct / 100);
     global.style.left = `${x}px`;
+  }
+
+  private _invalidateGlobalCursorLayout(): void {
+    this._globalCursorLayoutValid = false;
+  }
+
+  private _ensureGlobalCursorLayout(): boolean {
+    if (this._globalCursorLayoutValid) return true;
+
+    const rowsWrap = this._rowsWrap;
+    const firstRow = this._rows.values().next().value as RowMeta | undefined;
+    if (!rowsWrap || !firstRow) return false;
+
+    // Anchor to the track start (not full row start) so x=0 aligns to the
+    // first pattern block instead of the M/S controls.
+    const wrapRect = rowsWrap.getBoundingClientRect();
+    const trackRect = firstRow.track.getBoundingClientRect();
+    if (wrapRect.width <= 0 || trackRect.width <= 0) return false;
+
+    this._globalCursorXOffset = trackRect.left - wrapRect.left;
+    this._globalCursorTrackWidth = trackRect.width;
+    this._globalCursorLayoutValid = true;
+    return true;
+  }
+
+  private _setupLayoutObserver(): void {
+    this._teardownLayoutObserver();
+    const rowsWrap = this._rowsWrap;
+    const firstRow = this._rows.values().next().value as RowMeta | undefined;
+    if (!rowsWrap || !firstRow || typeof ResizeObserver === 'undefined') return;
+
+    this._layoutObserver = new ResizeObserver(() => {
+      this._invalidateGlobalCursorLayout();
+    });
+    this._layoutObserver.observe(rowsWrap);
+    this._layoutObserver.observe(firstRow.track);
+  }
+
+  private _teardownLayoutObserver(): void {
+    this._layoutObserver?.disconnect();
+    this._layoutObserver = null;
   }
 
   private _syncMuteSolo(): void {

--- a/apps/web-ui/tests/__mocks__/monaco-editor.ts
+++ b/apps/web-ui/tests/__mocks__/monaco-editor.ts
@@ -34,10 +34,14 @@ export const languages = {
   registerCompletionItemProvider: jest.fn(),
   registerHoverProvider: jest.fn(),
   registerCodeLensProvider: jest.fn(),
+  registerFoldingRangeProvider: jest.fn(),
   registerDocumentHighlightProvider: jest.fn(),
   registerDocumentSemanticTokensProvider: jest.fn(),
   registerDocumentFormattingEditProvider: jest.fn(),
   registerSignatureHelpProvider: jest.fn(),
+  FoldingRangeKind: {
+    Comment: 1,
+  },
   typescript: {
     javascriptDefaults: {
       setDiagnosticsOptions: jest.fn(),
@@ -60,6 +64,11 @@ export const MarkerSeverity = {
   Info: 2,
 };
 
+export const GlyphMarginLane = {
+  Left: 1,
+  Right: 2,
+};
+
 export class Range {
   constructor(public startLineNumber: number, public startColumn: number, public endLineNumber: number, public endColumn: number) {}
 }
@@ -68,6 +77,7 @@ export default {
   editor,
   languages,
   MarkerSeverity,
+  GlyphMarginLane,
   KeyMod,
   KeyCode,
 };

--- a/apps/web-ui/tests/beatbax-language.envelope-hover.test.ts
+++ b/apps/web-ui/tests/beatbax-language.envelope-hover.test.ts
@@ -1,0 +1,215 @@
+import * as monaco from 'monaco-editor';
+import {
+  parseEnvelopeAtPosition,
+  simulateGBEnvelope,
+  renderEnvelopeSparkline,
+} from '../src/editor/beatbax-language';
+import { registerBeatBaxLanguage } from '../src/editor/beatbax-language';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeModel(line: string) {
+  return {
+    getLineContent: jest.fn(() => line),
+    getWordAtPosition: jest.fn(() => null),
+  } as any as monaco.editor.ITextModel;
+}
+
+function pos(col: number) {
+  return { lineNumber: 1, column: col } as monaco.IPosition;
+}
+
+function colOf(line: string, substr: string, offset = 0) {
+  return line.indexOf(substr) + offset + 1; // 1-based
+}
+
+// ── parseEnvelopeAtPosition ───────────────────────────────────────────────────
+
+describe('parseEnvelopeAtPosition', () => {
+  describe('JSON form', () => {
+    const line = 'inst p type=pulse2 duty=50 env={"level":12,"direction":"down","period":1,"format":"gb"}';
+
+    it('detects envelope when cursor is on level value', () => {
+      const col = colOf(line, '12');
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe(12);
+      expect(result!.direction).toBe('down');
+      expect(result!.period).toBe(1);
+    });
+
+    it('detects envelope when cursor is on direction string', () => {
+      const col = colOf(line, 'down');
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe('down');
+    });
+
+    it('returns null when cursor is before the env= token', () => {
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(1));
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('gb-prefixed form', () => {
+    const line = 'inst p type=pulse1 duty=50 env=gb:15,down,2';
+
+    it('parses level, direction, period', () => {
+      const col = colOf(line, 'gb:15');
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe(15);
+      expect(result!.direction).toBe('down');
+      expect(result!.period).toBe(2);
+    });
+  });
+
+  describe('short form', () => {
+    it('parses level + direction + optional period', () => {
+      const line = 'inst p type=pulse1 duty=50 env=10,up,3';
+      const col = colOf(line, '10,up,3');
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe(10);
+      expect(result!.direction).toBe('up');
+      expect(result!.period).toBe(3);
+    });
+
+    it('defaults period to 0 when omitted', () => {
+      const line = 'inst p type=pulse1 env=8,down';
+      const col = colOf(line, '8,down');
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.period).toBe(0);
+    });
+
+    it('handles flat direction', () => {
+      const line = 'inst p type=pulse1 env=15,flat';
+      const col = colOf(line, 'flat');
+      const result = parseEnvelopeAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe('flat');
+    });
+  });
+});
+
+// ── simulateGBEnvelope ────────────────────────────────────────────────────────
+
+describe('simulateGBEnvelope', () => {
+  it('starts at initial level', () => {
+    const env = { level: 12, direction: 'down' as const, period: 2, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 5);
+    expect(steps[0]).toBe(12);
+  });
+
+  it('decrements every period steps (down direction)', () => {
+    const env = { level: 4, direction: 'down' as const, period: 2, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 6);
+    // step 0: 4, step 1: 4, step 2: 3, step 3: 3, step 4: 2, step 5: 2
+    expect(steps).toEqual([4, 4, 3, 3, 2, 2]);
+  });
+
+  it('increments every period steps (up direction)', () => {
+    const env = { level: 13, direction: 'up' as const, period: 1, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 4);
+    expect(steps).toEqual([13, 14, 15, 15]);
+  });
+
+  it('holds flat when direction is flat', () => {
+    const env = { level: 8, direction: 'flat' as const, period: 1, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 4);
+    expect(steps).toEqual([8, 8, 8, 8]);
+  });
+
+  it('holds constant when period is 0', () => {
+    const env = { level: 10, direction: 'down' as const, period: 0, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 4);
+    expect(steps).toEqual([10, 10, 10, 10]);
+  });
+
+  it('clamps output at 0 (never negative)', () => {
+    const env = { level: 1, direction: 'down' as const, period: 1, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 5);
+    expect(steps.every((v) => v >= 0)).toBe(true);
+    expect(steps[2]).toBe(0);
+  });
+
+  it('clamps output at 15 (never above max)', () => {
+    const env = { level: 14, direction: 'up' as const, period: 1, raw: '', range: {} as any };
+    const steps = simulateGBEnvelope(env, 5);
+    expect(steps.every((v) => v <= 15)).toBe(true);
+    expect(steps[2]).toBe(15);
+  });
+});
+
+// ── renderEnvelopeSparkline ───────────────────────────────────────────────────
+
+describe('renderEnvelopeSparkline', () => {
+  it('returns string with same length as input', () => {
+    const line = renderEnvelopeSparkline([0, 4, 8, 12, 15]);
+    expect(line).toHaveLength(5);
+  });
+
+  it('renders 0 as a space character', () => {
+    const line = renderEnvelopeSparkline([0]);
+    expect(line).toBe(' ');
+  });
+
+  it('renders 15 as full block █', () => {
+    const line = renderEnvelopeSparkline([15]);
+    expect(line).toBe('█');
+  });
+
+  it('renders a falling envelope visually', () => {
+    const line = renderEnvelopeSparkline([15, 12, 9, 6, 3, 0]);
+    // Each subsequent character should encode a lower or equal block height
+    const chars = ' ▁▂▃▄▅▆▇█';
+    const indices = [...line].map((c) => chars.indexOf(c));
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeLessThanOrEqual(indices[i - 1]);
+    }
+  });
+});
+
+// ── provideHover integration ──────────────────────────────────────────────────
+
+describe('provideHover — envelope hover', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  it('returns envelope hover for JSON env= value', () => {
+    const provider = getHoverProvider();
+    const line = 'inst p type=pulse2 duty=50 env={"level":15,"direction":"down","period":1,"format":"gb"}';
+    const col = line.indexOf('"level"') + 4; // cursor inside JSON object
+
+    const model = makeModel(line);
+    const hover = provider.provideHover(model, pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('Envelope preview');
+    expect(hover.contents[1].value).toContain('```text');
+    expect(hover.contents[2].value).toContain('Initial level');
+    expect(hover.contents[2].value).toContain('15');
+    expect(hover.contents[2].value).toContain('down');
+  });
+
+  it('returns envelope hover for short form env=', () => {
+    const provider = getHoverProvider();
+    const line = 'inst p type=pulse1 env=12,down,1';
+    const col = colOf(line, '12,down');
+
+    const model = makeModel(line);
+    const hover = provider.provideHover(model, pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('Envelope preview');
+  });
+});

--- a/apps/web-ui/tests/beatbax-language.hover.test.ts
+++ b/apps/web-ui/tests/beatbax-language.hover.test.ts
@@ -6,6 +6,26 @@ describe('BeatBax Monaco hover provider', () => {
     jest.clearAllMocks();
   });
 
+  function makeMultilineModel(lines: string[]) {
+    return {
+      getLineCount: jest.fn(() => lines.length),
+      getLineContent: jest.fn((lineNumber: number) => lines[lineNumber - 1] ?? ''),
+      getWordAtPosition: jest.fn((position: monaco.IPosition) => {
+        const line = lines[position.lineNumber - 1] ?? '';
+        const idx = Math.max(0, position.column - 1);
+        const left = line.slice(0, idx).match(/[a-zA-Z_]\w*$/)?.[0] ?? '';
+        const right = line.slice(idx).match(/^\w*/)?.[0] ?? '';
+        const word = left + right;
+        if (!word) return null;
+        return {
+          word,
+          startColumn: idx - left.length + 1,
+          endColumn: idx + right.length + 1,
+        };
+      }),
+    } as any;
+  }
+
   function getHoverProvider() {
     registerBeatBaxLanguage();
     const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
@@ -49,5 +69,20 @@ describe('BeatBax Monaco hover provider', () => {
 
     expect(hover).toBeTruthy();
     expect(hover.contents[0].value).toContain('target audio chip');
+  });
+
+  test('suppresses hovers on continuation lines inside triple-quoted metadata', () => {
+    const hoverProvider = getHoverProvider();
+    const lines = [
+      'song description """Opening line with lead mention',
+      'middle line with lead and ghost names',
+      'closing line"""',
+    ];
+    const model = makeMultilineModel(lines);
+    const column = lines[1].indexOf('lead') + 2;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 2, column });
+
+    expect(hover).toBeNull();
   });
 });

--- a/apps/web-ui/tests/beatbax-language.hover.test.ts
+++ b/apps/web-ui/tests/beatbax-language.hover.test.ts
@@ -1,0 +1,53 @@
+import * as monaco from 'monaco-editor';
+import { registerBeatBaxLanguage } from '../src/editor/beatbax-language';
+
+describe('BeatBax Monaco hover provider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  test('shows waveform sparkline when hovering wave array values', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst w type=wave wave=[0,3,6,9,12,9,6,3]';
+    const sixColumn = line.indexOf('6') + 1;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => null),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column: sixColumn });
+
+    expect(hover).toBeTruthy();
+    expect(hover.contents[0].value).toContain('Waveform preview');
+    expect(hover.contents[1].value).toContain('```text');
+    expect(hover.contents[1].value).toContain('^');
+    expect(hover.contents[2].value).toContain('Samples: 8');
+    expect(hover.contents[2].value).toContain('Index');
+  });
+
+  test('falls back to keyword hover docs when not inside wave literal', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'chip gameboy';
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({ word: 'chip', startColumn: 1, endColumn: 5 })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column: 2 });
+
+    expect(hover).toBeTruthy();
+    expect(hover.contents[0].value).toContain('target audio chip');
+  });
+});

--- a/apps/web-ui/tests/beatbax-language.nes-macro-hover.test.ts
+++ b/apps/web-ui/tests/beatbax-language.nes-macro-hover.test.ts
@@ -1,0 +1,248 @@
+import * as monaco from 'monaco-editor';
+import {
+  parseNesMacroAtPosition,
+  renderNesMacroSparkline,
+  ParsedNesMacro,
+} from '../src/editor/beatbax-language';
+import { registerBeatBaxLanguage } from '../src/editor/beatbax-language';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeModel(line: string) {
+  return {
+    getLineContent: jest.fn(() => line),
+    getWordAtPosition: jest.fn(() => null),
+  } as any as monaco.editor.ITextModel;
+}
+
+function pos(col: number) {
+  return { lineNumber: 1, column: col } as monaco.IPosition;
+}
+
+function colOf(line: string, substr: string, offset = 0): number {
+  return line.indexOf(substr) + offset + 1; // 1-based
+}
+
+// ── parseNesMacroAtPosition ───────────────────────────────────────────────────
+
+describe('parseNesMacroAtPosition', () => {
+  describe('vol_env', () => {
+    const line = 'inst i_kick type=noise noise_period=12 vol_env=[15,12,8,4,2,1]';
+
+    it('returns macroType vol_env when cursor is inside bracket', () => {
+      const col = colOf(line, '15,12');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.macroType).toBe('vol_env');
+    });
+
+    it('parses values correctly', () => {
+      const col = colOf(line, '[15,12');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result!.values).toEqual([15, 12, 8, 4, 2, 1]);
+    });
+
+    it('loopPoint is -1 when no | is present', () => {
+      const col = colOf(line, '15,12');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result!.loopPoint).toBe(-1);
+    });
+
+    it('returns null when cursor is before vol_env token', () => {
+      const result = parseNesMacroAtPosition(makeModel(line), pos(1));
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('vol_env with loop point', () => {
+    const line = 'inst p vol_env=[1,2,3,4,5,6,7,8,9,10|9]';
+
+    it('parses loop point correctly', () => {
+      const col = colOf(line, '1,2,3');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.values).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      expect(result!.loopPoint).toBe(9);
+    });
+  });
+
+  describe('arp_env', () => {
+    const line = 'inst p type=pulse1 arp_env=[0,4,7|0]';
+
+    it('returns macroType arp_env', () => {
+      const col = colOf(line, '0,4,7');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.macroType).toBe('arp_env');
+    });
+
+    it('parses values and loop point', () => {
+      const col = colOf(line, '[0,4,7');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result!.values).toEqual([0, 4, 7]);
+      expect(result!.loopPoint).toBe(0);
+    });
+  });
+
+  describe('pitch_env', () => {
+    const line = 'inst p type=pulse2 pitch_env=[5,4,3,2,1,0,0,0]';
+
+    it('returns macroType pitch_env', () => {
+      const col = colOf(line, '5,4,3');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.macroType).toBe('pitch_env');
+    });
+
+    it('parses descending pitch values', () => {
+      const col = colOf(line, '[5,4');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result!.values).toEqual([5, 4, 3, 2, 1, 0, 0, 0]);
+    });
+
+    it('handles negative semitone offsets', () => {
+      const line2 = 'inst p pitch_env=[0,0,-1,-2,-1,0]';
+      const col = colOf(line2, '-1');
+      const result = parseNesMacroAtPosition(makeModel(line2), pos(col));
+      expect(result!.values).toContain(-1);
+      expect(result!.values).toContain(-2);
+    });
+  });
+
+  describe('duty_env', () => {
+    const line = 'inst p type=pulse1 duty_env=[2,2,2,2,2,2,2,2,0,0,0,0,0,0,0,0|0]';
+
+    it('returns macroType duty_env', () => {
+      const col = colOf(line, '2,2,2');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result).not.toBeNull();
+      expect(result!.macroType).toBe('duty_env');
+    });
+
+    it('parses values and loop point for wah pattern', () => {
+      const col = colOf(line, '[2,2,2');
+      const result = parseNesMacroAtPosition(makeModel(line), pos(col));
+      expect(result!.values).toHaveLength(16);
+      expect(result!.loopPoint).toBe(0);
+    });
+  });
+});
+
+// ── renderNesMacroSparkline ───────────────────────────────────────────────────
+
+describe('renderNesMacroSparkline', () => {
+  it('returns a string with the same length as input', () => {
+    const line = renderNesMacroSparkline([0, 5, 10, 15], 0, 15);
+    expect(line).toHaveLength(4);
+  });
+
+  it('renders 0 at min as a space', () => {
+    expect(renderNesMacroSparkline([0], 0, 15)).toBe(' ');
+  });
+
+  it('renders max as full block █', () => {
+    expect(renderNesMacroSparkline([15], 0, 15)).toBe('█');
+  });
+
+  it('normalizes values relative to given min/max (non-zero min)', () => {
+    // With min=0, max=7 and value=7 → should be '█'
+    const line = renderNesMacroSparkline([0, 7], 0, 7);
+    expect(line[1]).toBe('█');
+    expect(line[0]).toBe(' ');
+  });
+
+  it('handles all same values (no range) without crashing', () => {
+    const line = renderNesMacroSparkline([5, 5, 5], 5, 5);
+    expect(line).toHaveLength(3);
+  });
+
+  it('renders falling vol_env visually (each char same or lower)', () => {
+    const chars = ' ▁▂▃▄▅▆▇█';
+    const vals = [15, 12, 8, 4, 2, 1];
+    const line = renderNesMacroSparkline(vals, 0, 15);
+    const indices = [...line].map((c) => chars.indexOf(c));
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeLessThanOrEqual(indices[i - 1]);
+    }
+  });
+});
+
+// ── provideHover integration ──────────────────────────────────────────────────
+
+describe('provideHover — NES macro hover', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  it('returns vol_env hover with sparkline and frame count', () => {
+    const provider = getHoverProvider();
+    const line = 'inst i_kick type=noise noise_period=12 vol_env=[15,12,8,4,2,1]';
+    const col = colOf(line, '15,12');
+
+    const hover = provider.provideHover(makeModel(line), pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('Volume envelope');
+    expect(hover.contents[1].value).toContain('```text');
+    expect(hover.contents[2].value).toContain('Frames: **6**');
+    expect(hover.contents[2].value).toContain('One-shot');
+  });
+
+  it('returns arp_env hover with semitone offsets', () => {
+    const provider = getHoverProvider();
+    const line = 'inst p type=pulse1 arp_env=[0,4,7|0]';
+    const col = colOf(line, '0,4,7');
+
+    const hover = provider.provideHover(makeModel(line), pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('Arpeggio envelope');
+    expect(hover.contents[2].value).toContain('+4');
+    expect(hover.contents[2].value).toContain('+7');
+    expect(hover.contents[2].value).toContain('Loops from index **0**');
+  });
+
+  it('returns pitch_env hover with FamiTracker unit note', () => {
+    const provider = getHoverProvider();
+    const line = 'inst p type=pulse2 pitch_env=[5,4,3,2,1,0,0,0]';
+    const col = colOf(line, '5,4,3');
+
+    const hover = provider.provideHover(makeModel(line), pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('Pitch envelope');
+    expect(hover.contents[2].value).toContain('multiplied by 16');
+  });
+
+  it('returns duty_env hover with duty cycle labels', () => {
+    const provider = getHoverProvider();
+    const line = 'inst p type=pulse1 duty_env=[0,1,2,3]';
+    const col = colOf(line, '0,1,2,3');
+
+    const hover = provider.provideHover(makeModel(line), pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('Duty envelope');
+    expect(hover.contents[2].value).toContain('12.5%');
+    expect(hover.contents[2].value).toContain('25%');
+    expect(hover.contents[2].value).toContain('50%');
+    expect(hover.contents[2].value).toContain('75%');
+  });
+
+  it('does not fire when cursor is before the macro token', () => {
+    const provider = getHoverProvider();
+    const line = 'inst i_kick type=noise noise_period=12 vol_env=[15,12,8,4,2,1]';
+
+    const hover = provider.provideHover(makeModel(line), pos(1));
+
+    // cursor is on 'inst' keyword — mock returns null word → no hover
+    expect(hover).toBeNull();
+  });
+});

--- a/apps/web-ui/tests/channel-mixer.test.ts
+++ b/apps/web-ui/tests/channel-mixer.test.ts
@@ -309,6 +309,28 @@ describe('ChannelMixer', () => {
     expect(strip2?.classList.contains('bb-channel-mixer__strip--silent')).toBe(true);
   });
 
+  it('solo button auto-unmutes a muted channel', () => {
+    eventBus.emit('parse:success', { ast: makeAst([1, 2]) });
+    channelStore.setChannelMuted(1, true);
+
+    const soloBtn = document.getElementById('bb-channel-mixer-solo-1') as HTMLButtonElement | null;
+    soloBtn?.click();
+
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(false);
+  });
+
+  it('mute button auto-unsolos a soloed channel', () => {
+    eventBus.emit('parse:success', { ast: makeAst([1, 2]) });
+    channelStore.toggleChannelSoloed(1);
+
+    const muteBtn = document.getElementById('bb-channel-mixer-mute-1') as HTMLButtonElement | null;
+    muteBtn?.click();
+
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(false);
+  });
+
   // ── Unmute All / Clear Solo toolbar buttons ────────────────────────────────
 
   it('unmute-all button is disabled when no channels are muted', () => {

--- a/apps/web-ui/tests/command-palette.test.ts
+++ b/apps/web-ui/tests/command-palette.test.ts
@@ -19,7 +19,7 @@ bpm 120
 time 4
 inst lead  type=pulse1 duty=50 env=12,down
 inst bass  type=pulse2 duty=25 env=10,down
-inst wave1 type=wave   wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave   wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst sn    type=noise  env=12,down
 pat melody   = C4 E4 G4 C5
 pat bass_pat = C3 . G2 .

--- a/apps/web-ui/tests/glyph-margin.test.ts
+++ b/apps/web-ui/tests/glyph-margin.test.ts
@@ -3,8 +3,8 @@
  *
  * Verifies both glyph-margin features:
  *  1. Playback position cursor  — ▶ glyph on the currently-playing `pat` line
- *  2. Channel mute/solo glyphs — speaker glyph on `channel N =>` lines,
- *                                clickable to toggle mute
+ *  2. Channel mute/solo glyphs — M (left lane) and S (right lane) badges on
+ *                                `channel N =>` lines, clickable per lane
  */
 
 import { EventBus } from '../src/utils/event-bus';
@@ -62,7 +62,7 @@ describe('GlyphMargin', () => {
 
   // ── parse:success ──────────────────────────────────────────────────────────
 
-  it('adds live-channel glyphs on both channel lines after parse:success', () => {
+  it('adds mute/solo lane glyphs on both channel lines after parse:success', () => {
     setupGlyphMargin(mockEditor, eventBus as any);
     eventBus.emit('parse:success', { ast: {} });
 
@@ -70,14 +70,22 @@ describe('GlyphMargin', () => {
     const lastCall = deltaDecorations.mock.calls[deltaDecorations.mock.calls.length - 1];
     const decors: any[] = lastCall[1];
 
-    // channel 1 => is line 6, channel 2 => is line 7
-    const ch1 = decors.find((d) => d.range.startLineNumber === 6);
-    const ch2 = decors.find((d) => d.range.startLineNumber === 7);
+    // channel 1 => line 6, channel 2 => line 7; each line gets mute + solo lane glyphs
+    const line6 = decors.filter((d) => d.range.startLineNumber === 6);
+    const line7 = decors.filter((d) => d.range.startLineNumber === 7);
 
-    expect(ch1).toBeDefined();
-    expect(ch1.options.glyphMarginClassName).toBe('bb-glyph--ch-live');
-    expect(ch2).toBeDefined();
-    expect(ch2.options.glyphMarginClassName).toBe('bb-glyph--ch-live');
+    expect(line6).toHaveLength(2);
+    expect(line7).toHaveLength(2);
+
+    const ch1Mute = line6.find((d) => d.options.glyphMarginClassName === 'bb-glyph--ch-mute-off');
+    const ch1Solo = line6.find((d) => d.options.glyphMarginClassName === 'bb-glyph--ch-solo-off');
+    const ch2Mute = line7.find((d) => d.options.glyphMarginClassName === 'bb-glyph--ch-mute-off');
+    const ch2Solo = line7.find((d) => d.options.glyphMarginClassName === 'bb-glyph--ch-solo-off');
+
+    expect(ch1Mute?.options.glyphMargin?.position).toBe((monaco as any).GlyphMarginLane.Left);
+    expect(ch1Solo?.options.glyphMargin?.position).toBe((monaco as any).GlyphMarginLane.Right);
+    expect(ch2Mute?.options.glyphMargin?.position).toBe((monaco as any).GlyphMarginLane.Left);
+    expect(ch2Solo?.options.glyphMargin?.position).toBe((monaco as any).GlyphMarginLane.Right);
   });
 
   it('clears stale position glyphs on parse:success', () => {
@@ -369,8 +377,9 @@ describe('GlyphMargin', () => {
     eventBus.emit('channel:muted', { channel: 1 });
 
     const lastCall = deltaDecorations.mock.calls[deltaDecorations.mock.calls.length - 1];
-    const ch1Decor = lastCall[1].find((d: any) => d.range.startLineNumber === 6);
-    expect(ch1Decor?.options.glyphMarginClassName).toBe('bb-glyph--ch-muted');
+    const line6 = lastCall[1].filter((d: any) => d.range.startLineNumber === 6);
+    expect(line6.find((d: any) => d.options.glyphMarginClassName === 'bb-glyph--ch-mute-on')).toBeDefined();
+    expect(line6.find((d: any) => d.options.glyphMarginClassName === 'bb-glyph--ch-solo-off')).toBeDefined();
   });
 
   it('restores live glyph on channel line after channel:unmuted', () => {
@@ -381,8 +390,8 @@ describe('GlyphMargin', () => {
     eventBus.emit('channel:unmuted', { channel: 1 });
 
     const lastCall = deltaDecorations.mock.calls[deltaDecorations.mock.calls.length - 1];
-    const ch1Decor = lastCall[1].find((d: any) => d.range.startLineNumber === 6);
-    expect(ch1Decor?.options.glyphMarginClassName).toBe('bb-glyph--ch-live');
+    const line6 = lastCall[1].filter((d: any) => d.range.startLineNumber === 6);
+    expect(line6.find((d: any) => d.options.glyphMarginClassName === 'bb-glyph--ch-mute-off')).toBeDefined();
   });
 
   it('shows soloed glyph on channel line after channel:soloed', () => {
@@ -395,8 +404,9 @@ describe('GlyphMargin', () => {
     eventBus.emit('channel:soloed', { channel: 1 });
 
     const lastCall = deltaDecorations.mock.calls[deltaDecorations.mock.calls.length - 1];
-    const ch1Decor = lastCall[1].find((d: any) => d.range.startLineNumber === 6);
-    expect(ch1Decor?.options.glyphMarginClassName).toBe('bb-glyph--ch-soloed');
+    const line6 = lastCall[1].filter((d: any) => d.range.startLineNumber === 6);
+    expect(line6.find((d: any) => d.options.glyphMarginClassName === 'bb-glyph--ch-solo-on')).toBeDefined();
+    expect(line6.find((d: any) => d.options.glyphMarginClassName === 'bb-glyph--ch-mute-off')).toBeDefined();
   });
 
   it('restores live glyph on channel line after channel:unsoloed', () => {
@@ -407,37 +417,78 @@ describe('GlyphMargin', () => {
     eventBus.emit('channel:unsoloed', { channel: 1 });
 
     const lastCall = deltaDecorations.mock.calls[deltaDecorations.mock.calls.length - 1];
-    const ch1Decor = lastCall[1].find((d: any) => d.range.startLineNumber === 6);
-    expect(ch1Decor?.options.glyphMarginClassName).toBe('bb-glyph--ch-live');
+    const line6 = lastCall[1].filter((d: any) => d.range.startLineNumber === 6);
+    expect(line6.find((d: any) => d.options.glyphMarginClassName === 'bb-glyph--ch-solo-off')).toBeDefined();
   });
 
-  // ── Glyph-margin click → toggle mute ─────────────────────────────────────
+  // ── Glyph-margin click → lane-based toggle ───────────────────────────────
 
-  it('toggles mute when clicking on a channel glyph', () => {
-    setupGlyphMargin(mockEditor, eventBus as any);
-    eventBus.emit('parse:success', { ast: {} });
-
-    // Simulate clicking the glyph on channel 1's line (line 6)
+  function marginClick(lineNumber: number, lane: 'left' | 'right') {
+    const width = 20;
+    const left = 100;
+    const offsetX = lane === 'left' ? left + 4 : left + width - 4;
     mouseDownHandler!({
       target: {
         type: (monaco.editor as any).MouseTargetType.GUTTER_GLYPH_MARGIN,
-        position: { lineNumber: 6 },
+        position: { lineNumber },
+        detail: {
+          glyphMarginLeft: left,
+          glyphMarginWidth: width,
+          offsetX,
+          isAfterLines: false,
+          lineNumbersWidth: 0,
+        },
       },
     });
+  }
+
+  it('toggles mute when clicking left lane on a channel line', () => {
+    setupGlyphMargin(mockEditor, eventBus as any);
+    eventBus.emit('parse:success', { ast: {} });
+
+    marginClick(6, 'left');
 
     expect(channelStore.channelStates.get()[1]?.muted).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(false);
   });
 
-  it('toggles mute on the correct channel when clicking channel 2', () => {
+  it('toggles solo when clicking right lane on a channel line', () => {
     setupGlyphMargin(mockEditor, eventBus as any);
     eventBus.emit('parse:success', { ast: {} });
 
-    mouseDownHandler!({
-      target: {
-        type: (monaco.editor as any).MouseTargetType.GUTTER_GLYPH_MARGIN,
-        position: { lineNumber: 7 },
-      },
-    });
+    marginClick(6, 'right');
+
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(false);
+  });
+
+  it('right-lane solo click auto-unmutes a muted channel', () => {
+    setupGlyphMargin(mockEditor, eventBus as any);
+    eventBus.emit('parse:success', { ast: {} });
+    channelStore.setChannelMuted(1, true);
+
+    marginClick(6, 'right');
+
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(false);
+  });
+
+  it('left-lane mute click auto-unsolos a soloed channel', () => {
+    setupGlyphMargin(mockEditor, eventBus as any);
+    eventBus.emit('parse:success', { ast: {} });
+    channelStore.toggleChannelSoloed(1);
+
+    marginClick(6, 'left');
+
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(false);
+  });
+
+  it('toggles mute on the correct channel when clicking channel 2 left lane', () => {
+    setupGlyphMargin(mockEditor, eventBus as any);
+    eventBus.emit('parse:success', { ast: {} });
+
+    marginClick(7, 'left');
 
     expect(channelStore.channelStates.get()[2]?.muted).toBe(true);
   });
@@ -450,6 +501,13 @@ describe('GlyphMargin', () => {
       target: {
         type: 4, // not GUTTER_GLYPH_MARGIN
         position: { lineNumber: 6 },
+        detail: {
+          glyphMarginLeft: 100,
+          glyphMarginWidth: 20,
+          offsetX: 104,
+          isAfterLines: false,
+          lineNumbersWidth: 0,
+        },
       },
     });
 
@@ -461,12 +519,7 @@ describe('GlyphMargin', () => {
     eventBus.emit('parse:success', { ast: {} });
 
     // Line 2 is a pat line, not a channel line
-    mouseDownHandler!({
-      target: {
-        type: (monaco.editor as any).MouseTargetType.GUTTER_GLYPH_MARGIN,
-        position: { lineNumber: 2 },
-      },
-    });
+    marginClick(2, 'left');
 
     expect(channelStore.channelStates.get()[1]?.muted).toBe(false);
   });

--- a/apps/web-ui/tests/metadata-hover-context.test.ts
+++ b/apps/web-ui/tests/metadata-hover-context.test.ts
@@ -32,7 +32,7 @@ describe('Metadata hover context detection', () => {
     return inQuote;
   }
 
-  it('detects text inside single-quoted strings', () => {
+  it('detects text inside double-quoted strings', () => {
     const line = 'song description "text with lead here"';
     // Position 27 is at 'l' in 'lead'
     expect(isPositionInString(line, 27)).toBe(true);

--- a/apps/web-ui/tests/metadata-hover-context.test.ts
+++ b/apps/web-ui/tests/metadata-hover-context.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Test that instrument/effect hovers are suppressed inside metadata strings
+ */
+
+describe('Metadata hover context detection', () => {
+  /**
+   * Helper to check if a position is inside a quoted string.
+   * This mimics the isPositionInString function used in beatbax-language.ts
+   */
+  function isPositionInString(line: string, column: number): boolean {
+    const upToCursor = line.substring(0, column - 1);
+
+    let i = 0;
+    let inQuote = false;
+
+    while (i < upToCursor.length) {
+      // Check for triple quotes first
+      if (upToCursor.substring(i, i + 3) === '"""') {
+        inQuote = !inQuote;
+        i += 3;
+      } else if (upToCursor[i] === '"') {
+        // Only toggle if not preceded by another quote
+        if (!inQuote || upToCursor.substring(i - 2, i) !== '""') {
+          inQuote = !inQuote;
+        }
+        i += 1;
+      } else {
+        i += 1;
+      }
+    }
+
+    return inQuote;
+  }
+
+  it('detects text inside single-quoted strings', () => {
+    const line = 'song description "text with lead here"';
+    // Position 27 is at 'l' in 'lead'
+    expect(isPositionInString(line, 27)).toBe(true);
+  });
+
+  it('detects text inside triple-quoted strings', () => {
+    const line = 'song description """lead, ghost, kick and snare"""';
+    // Position 28 is at 'l' in 'lead'
+    expect(isPositionInString(line, 28)).toBe(true);
+  });
+
+  it('detects instrument names outside quotes (should allow hover)', () => {
+    const line = 'inst lead type=pulse1 duty=50';
+    // Position 6 is at 'l' in 'lead' (after 'inst ')
+    expect(isPositionInString(line, 6)).toBe(false);
+  });
+
+  it('detects closing quote boundary correctly', () => {
+    const line = 'song description "lead"';
+    // Position 23 is at closing quote - should still be inside
+    expect(isPositionInString(line, 23)).toBe(true);
+    // Position 24 is after closing quote - should be outside
+    expect(isPositionInString(line, 24)).toBe(false);
+  });
+
+  it('handles escaped quotes in song metadata', () => {
+    const line = 'song description "NES-style with kick snare and lead"';
+    // Multiple instrument names inside quotes
+    expect(isPositionInString(line, 28)).toBe(true); // 'k' in 'kick'
+    expect(isPositionInString(line, 34)).toBe(true); // 's' in 'snare'
+    expect(isPositionInString(line, 44)).toBe(true); // 'l' in 'lead'
+  });
+
+  it('preserves hover for actual definitions outside strings', () => {
+    const lines = [
+      'inst lead type=pulse1',      // line 1: definition, no hover suppression
+      'inst ghost type=noise',      // line 2: definition, no hover suppression
+      'song description "lead ghost kick"', // line 3: in string, hover suppressed
+      'channel 1 => inst lead seq main', // line 4: reference outside string, no suppression
+    ];
+
+    // Line 1: 'lead' after 'inst ' - outside quotes
+    expect(isPositionInString(lines[0], 6)).toBe(false);
+
+    // Line 2: 'ghost' after 'inst ' - outside quotes
+    expect(isPositionInString(lines[1], 6)).toBe(false);
+
+    // Line 3: all three instrument names inside quotes
+    const line3 = lines[2]; // 'song description "lead ghost kick"'
+    const posInQuote = line3.indexOf('"lead') + 2; // position of 'l' in 'lead'
+    expect(isPositionInString(line3, posInQuote)).toBe(true);
+
+    // Line 4: 'lead' in channel assignment - outside quotes
+    expect(isPositionInString(lines[3], 29)).toBe(false);
+  });
+
+  it('handles multiline triple-quoted strings (single line check)', () => {
+    // Note: this test checks a single line from a multiline string
+    // The actual implementation needs to track state across lines
+    const line = 'The lead, ghost, kick and snare perform the intro."""';
+    // This is INSIDE a multiline string that started on previous line
+    // So triple-quote tracking would need to happen across lines
+    // For now, just check that quotes at the end toggle state
+    expect(isPositionInString(line, 5)).toBe(false); // before triple quote
+    expect(isPositionInString(line, 55)).toBe(true); // after triple quote toggle
+  });
+
+  it('real example from user report', () => {
+    // The actual metadata line from the user's issue
+    const line = 'song description """Original NES-style RPG battle chiptune at 155 BPM in A minor, inspired by the heroic, urgent battle music aesthetic of late-1980s NES RPGs (Final Fantasy era). Entirely original composition; no copyrighted material reproduced. Full 5-channel 2A03 arrangement: fanfare opening with duty_env shimmer on Pulse 1 stabs; 25% duty staccato Pulse 1 lead with driving 16th-note battle theme; 50% duty Pulse 2 parallel-fourth harmony with arp_env chord cycling in the bridge; repeating Am ostinato on Triangle; martial vol_env noise percussion with ghost hits; bundled @nes/ DMC kick/snare reinforcement."""';
+
+    // All these instrument names should be detected as INSIDE the string
+    const leadPos = line.indexOf('lead with');
+    expect(isPositionInString(line, leadPos + 1)).toBe(true);
+
+    const ghostPos = line.indexOf('ghost hits');
+    expect(isPositionInString(line, ghostPos + 1)).toBe(true);
+
+    const kickPos = line.indexOf('kick/snare');
+    expect(isPositionInString(line, kickPos + 1)).toBe(true);
+
+    const snarePos = line.indexOf('snare reinforcement');
+    expect(isPositionInString(line, snarePos + 1)).toBe(true);
+  });
+});

--- a/apps/web-ui/tests/song-visualizer.test.ts
+++ b/apps/web-ui/tests/song-visualizer.test.ts
@@ -101,4 +101,26 @@ describe('SongVisualizer', () => {
     const shownCanvas = document.getElementById('bb-viz-bg');
     expect(shownCanvas?.classList.contains('bb-viz__bg-hidden')).toBe(false);
   });
+
+  it('solo button auto-unmutes a muted channel', () => {
+    eventBus.emit('parse:success', { ast: makeAst([1, 2]) });
+    channelStore.setChannelMuted(1, true);
+
+    const soloBtn = document.getElementById('bb-viz-solo-1') as HTMLButtonElement | null;
+    soloBtn?.click();
+
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(false);
+  });
+
+  it('mute button auto-unsolos a soloed channel', () => {
+    eventBus.emit('parse:success', { ast: makeAst([1, 2]) });
+    channelStore.toggleChannelSoloed(1);
+
+    const muteBtn = document.getElementById('bb-viz-mute-1') as HTMLButtonElement | null;
+    muteBtn?.click();
+
+    expect(channelStore.channelStates.get()[1]?.muted).toBe(true);
+    expect(channelStore.channelStates.get()[1]?.soloed).toBe(false);
+  });
 });

--- a/docs/exports/uge-export-guide.md
+++ b/docs/exports/uge-export-guide.md
@@ -421,7 +421,7 @@ bpm 140
 
 inst lead type=pulse1 duty=50 env=gb:12,down,1
 inst bass type=pulse2 duty=25 env=gb:10,down,1
-inst arp type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst arp type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst kick type=noise env=gb:12,down,1
 
 pat melody = C5 E5 G5 C6

--- a/docs/exports/wav-export-guide.md
+++ b/docs/exports/wav-export-guide.md
@@ -15,7 +15,7 @@ bpm 128
 
 inst lead type=pulse1 duty=50 env=gb:12,down,1
 inst bass type=pulse2 duty=25 env=gb:10,down,1
-inst wave1 type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst snare type=noise env=gb:12,down,1
 
 pat melody = C5 E5 G5 C6

--- a/docs/features/complete/editor-interactive-features.md
+++ b/docs/features/complete/editor-interactive-features.md
@@ -172,7 +172,7 @@ Suggested commands to add:
   ```
   inst lead  type=pulse1 duty=50 env=12,down
   inst bass  type=pulse2 duty=25 env=10,down
-  inst wave1 type=wave   wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+  inst wave1 type=wave   wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
   inst sn    type=noise  env=12,down
   ```
   at the cursor position using `editor.executeEdits`.

--- a/docs/features/enhanced-command-palette-commands.md
+++ b/docs/features/enhanced-command-palette-commands.md
@@ -1,0 +1,431 @@
+---
+title: Enhanced Command Palette Commands
+status: proposed
+authors: ["kadraman", "GitHub Copilot"]
+created: 2026-04-26
+issue: "https://github.com/kadraman/beatbax/issues/96"
+---
+
+## Summary
+
+Extend the BeatBax command palette with navigation, editing, audition, analysis, and refactoring commands to improve authoring workflows and discoverability. These commands provide keyboard-driven access to common song-authoring tasks without requiring mouse interaction.
+
+## Problem Statement
+
+Current command palette coverage is limited to exports, basic generation, transforms, mute/solo, and validation. Composers lack keyboard-accessible commands for:
+
+- **Navigation**: Jumping to pattern/sequence/instrument definitions or finding all usages
+- **Audition**: Previewing individual patterns without manual source editing
+- **Discovery**: Listing all available definitions (patterns, sequences, instruments)
+- **Refactoring**: Renaming, duplicating, or extracting patterns
+- **Analysis**: Identifying unused definitions or checking sequence timing
+- **Output**: Quick clipboard export or resuming from editor cursor position
+
+## Proposed Solution
+
+### Command Categories
+
+#### 1. Navigation Commands
+
+**1.1 Go to Pattern Definition**
+- **ID**: `beatbax.gotoPatternDef`
+- **Label**: `BeatBax: Go to Pattern Definition`
+- **Trigger**: Cursor on a pattern reference (e.g., in a sequence body or channel transform)
+- **Behavior**: Jump to the `pat NAME =` line for that pattern
+- **Implementation**:
+  - Extract identifier under cursor using Monaco `getWordAtPosition`
+  - Search editor source for `^pat <identifier> =` regex
+  - Call `editor.revealLineInCenter()` and position cursor at match
+- **Keybinding**: Optional (suggest `Ctrl+Shift+D` for definition)
+
+**1.2 Go to Sequence Definition**
+- **ID**: `beatbax.gotoSeqDef`
+- **Label**: `BeatBax: Go to Sequence Definition`
+- **Trigger**: Cursor on a sequence reference
+- **Behavior**: Jump to the `seq NAME =` line
+- **Implementation**: Same pattern as Go to Pattern, but search for `^seq`
+- **Keybinding**: Optional
+
+**1.3 Find All References**
+- **ID**: `beatbax.findReferences`
+- **Label**: `BeatBax: Find All References`
+- **Trigger**: Cursor on any definition name (pat, seq, inst)
+- **Behavior**: Populate VS Code's Find widget with all usages of that identifier
+- **Implementation**:
+  - Extract identifier under cursor
+  - Use Monaco's `find.action.changeSearchString` to populate the search box
+  - Allow user to navigate results with existing find UI
+- **Keybinding**: Optional (suggest `Ctrl+Shift+F`)
+
+**1.4 List All Patterns / Sequences / Instruments**
+- **ID**: `beatbax.listDefinitions`
+- **Label**: `BeatBax: List All Definitions…`
+- **Trigger**: Command palette
+- **Behavior**: Quick-pick menu to jump to any pattern, sequence, or instrument definition
+- **Implementation**:
+  - Parse editor source for all `pat`, `seq`, `inst` definitions
+  - Build quick-pick array: `[{ label: 'pat melody', value: 'melody' }, ...]`
+  - On selection, call `gotoPatternDef` / `gotoSeqDef` / `gotoInstDef` internally
+- **Keybinding**: Optional
+
+#### 2. Editing & Organization Commands
+
+**2.1 Duplicate Pattern**
+- **ID**: `beatbax.duplicatePattern`
+- **Label**: `BeatBax: Duplicate Pattern`
+- **Trigger**: Cursor on a `pat NAME = ...` line
+- **Behavior**: Clone pattern with auto-generated name (e.g., `melody` → `melody_2`)
+- **Implementation**:
+  - Extract pattern name and full definition from cursor line
+  - Generate unique name by checking for existing `NAME_N` patterns
+  - Insert new definition after the original
+  - Prompt user to confirm or edit the new name
+- **Keybinding**: Optional
+
+**2.2 Duplicate Sequence**
+- **ID**: `beatbax.duplicateSeq`
+- **Label**: `BeatBax: Duplicate Sequence`
+- **Trigger**: Cursor on a `seq NAME = ...` line
+- **Behavior**: Clone sequence with auto-generated name
+- **Implementation**: Same pattern as Duplicate Pattern, but for sequences
+- **Keybinding**: Optional
+
+**2.3 Rename Pattern / Sequence / Instrument**
+- **ID**: `beatbax.renameDefinition`
+- **Label**: `BeatBax: Rename Definition…`
+- **Trigger**: Cursor on any definition name
+- **Behavior**: Prompt for new name and update all references throughout the song
+- **Implementation**:
+  - Extract old identifier under cursor
+  - Show quick-pick or input dialog for new name
+  - Use regex replace to update:
+    - `pat/seq/inst OLD_NAME` in all definitions
+    - References in channel assignments, sequence bodies, transforms
+  - Show confirmation of replacements
+- **Keybinding**: Optional (suggest `Ctrl+Shift+R` for rename)
+- **Safety**: Validate new name is a valid identifier; show if name already exists
+
+**2.4 Extract Selection to Pattern**
+- **ID**: `beatbax.extractToPattern`
+- **Label**: `BeatBax: Extract Selection to Pattern`
+- **Trigger**: User has selected note tokens (e.g., `C4 E4 G4`)
+- **Behavior**: Create a new `pat` definition from selection and replace original with reference
+- **Implementation**:
+  - Extract selected text
+  - Generate unique pattern name (e.g., `extracted_1`)
+  - Insert new pattern definition after current block
+  - Replace selection with new pattern name
+- **Keybinding**: Optional (suggest `Ctrl+Shift+E`)
+
+**2.5 Sort Definitions Alphabetically**
+- **ID**: `beatbax.sortDefinitions`
+- **Label**: `BeatBax: Sort Definitions…`
+- **Trigger**: Command palette; optionally show for selected text block
+- **Behavior**: Sort a consecutive block of pattern/sequence/instrument definitions
+- **Implementation**:
+  - Detect the current definition block (consecutive `pat` or `seq` lines)
+  - Sort alphabetically by name
+  - Preserve instrument types, bpm, time, chip directives (not sorted)
+- **Keybinding**: Optional
+- **Notes**: Respect existing blank-line groupings where possible
+
+#### 3. Audition & Playback Commands
+
+**3.1 Preview Pattern Under Cursor**
+- **ID**: `beatbax.previewPattern`
+- **Label**: `BeatBax: Preview Pattern Under Cursor`
+- **Trigger**: Cursor on a pattern reference or definition
+- **Behavior**: Play only that pattern (one-shot, 120 BPM, default instrument)
+- **Implementation**:
+  - Extract pattern name from cursor
+  - Generate minimal synthetic BeatBax source:
+    ```
+    chip gameboy
+    bpm 120
+    time 4
+    inst _tmp type=pulse1 duty=50 env=12,down
+    pat __preview__ = [pattern body]
+    channel 1 => inst _tmp seq __preview__
+    play
+    ```
+  - Call `onPlayRaw()` with synthetic source
+  - Stop on next selection or `Escape`
+- **Keybinding**: Optional (suggest `Alt+P` for preview)
+
+**3.2 Preview Sequence Under Cursor**
+- **ID**: `beatbax.previewSeq`
+- **Label**: `BeatBax: Preview Sequence Under Cursor`
+- **Trigger**: Cursor on a sequence reference or definition
+- **Behavior**: Play that sequence using current instrument or first declared instrument
+- **Implementation**: Same as Preview Pattern, but build synthetic source from sequence body
+- **Keybinding**: Optional
+
+**3.3 Play from Cursor Position**
+- **ID**: `beatbax.playFromCursor`
+- **Label**: `BeatBax: Play from Cursor Position`
+- **Trigger**: Command palette; editor has focus
+- **Behavior**: Resume main playback from the channel/sequence containing the cursor line
+- **Implementation**:
+  - Identify which channel and sequence the cursor is referencing
+  - Calculate elapsed time into that sequence (note count)
+  - Seek playback to that position and resume
+  - If main song not playing, start from that position
+- **Keybinding**: Optional (suggest `Alt+Shift+P`)
+
+#### 4. Analysis & Diagnostics Commands
+
+**4.1 Show Unused Definitions**
+- **ID**: `beatbax.showUnused`
+- **Label**: `BeatBax: Show Unused Definitions`
+- **Trigger**: Command palette
+- **Behavior**: List all patterns, sequences, and instruments that are never referenced
+- **Implementation**:
+  - Parse all definitions (pat, seq, inst)
+  - For each, search source for any reference (channel assignments, sequence bodies, transforms)
+  - Return list of unreferenced names in a quick-pick
+  - On selection, jump to that definition
+- **Output**: Dialog or quick-pick showing unused count per type (e.g., "4 unused patterns, 1 unused instrument")
+
+**4.2 Show Pattern Duration / Timing Info**
+- **ID**: `beatbax.showPatternInfo`
+- **Label**: `BeatBax: Show Pattern Duration`
+- **Trigger**: Cursor on a pattern definition
+- **Behavior**: Display note count, playback time (ms), and tick count
+- **Implementation**:
+  - Extract pattern body from cursor line
+  - Count note tokens (excluding rests)
+  - Calculate duration: `(noteCount / currentBPM) * 60000 ms`
+  - Show in hover or quick-info tooltip
+  - Format: `Pattern: 8 notes | ≈ 1.5s @ 120BPM | 120 ticks`
+- **Keybinding**: Optional
+
+**4.3 Audit Song for Common Issues**
+- **ID**: `beatbax.auditSong`
+- **Label**: `BeatBax: Audit Song for Issues`
+- **Trigger**: Command palette
+- **Behavior**: Check for:
+  - Unmatched instrument references (used but not defined)
+  - Unmatched pattern/sequence references
+  - Circular sequence definitions (seq A → seq B → seq A)
+  - Mismatched bpm/time settings across channel directives
+  - Sequences that exceed known device limits (Game Boy: ~2000 patterns per channel)
+- **Output**: Numbered list of issues with line numbers and auto-jump on selection
+- **Implementation**: Leverage existing `onVerify()` callback; add more granular checks
+- **Format**:
+  ```
+  ✗ Unmatched instrument: 'bass_drum' on line 42
+  ✗ Circular sequence: drum → arp → drum on lines 18, 25, 31
+  ✓ No issues found
+  ```
+
+#### 5. Channel Operations
+
+**5.1 Copy Channel Configuration**
+- **ID**: `beatbax.copyChannelConfig`
+- **Label**: `BeatBax: Copy Channel Configuration`
+- **Trigger**: Cursor on a `channel N =>` line
+- **Behavior**: Copy the full channel assignment to clipboard (e.g., `inst lead seq chorus`)
+- **Implementation**:
+  - Extract the channel line (everything after `=>`)
+  - Copy to clipboard using Monaco's clipboard API
+  - Show toast notification: "Copied: inst lead seq chorus"
+- **Keybinding**: Optional
+
+**5.2 Swap Channel Assignments**
+- **ID**: `beatbax.swapChannels`
+- **Label**: `BeatBax: Swap Channel Assignments…`
+- **Trigger**: Command palette
+- **Behavior**: Interactive swap of two channel definitions
+- **Implementation**:
+  - Show quick-pick listing current channels (e.g., "Channel 1: inst lead seq mel")
+  - User selects two channels
+  - Swap their `channel N =>` lines in the editor
+- **Keybinding**: Optional
+
+#### 6. Export & Output Convenience Commands
+
+**6.1 Export to Clipboard**
+- **ID**: `beatbax.exportToClipboard`
+- **Label**: `BeatBax: Export to Clipboard…`
+- **Trigger**: Command palette
+- **Behavior**: Quick-pick format (JSON/MIDI/UGE/WAV) and copy result to clipboard
+- **Implementation**:
+  - Show quick-pick: `['JSON', 'MIDI', 'UGE', 'WAV', 'FamiTracker']`
+  - On selection, export using existing `onExport()` callback
+  - Intercept the export result and copy to clipboard
+  - Show toast: "Exported JSON (1200 bytes) — copied to clipboard"
+- **Keybinding**: Optional
+
+**6.2 Quick Export (Last Format)**
+- **ID**: `beatbax.quickExport`
+- **Label**: `BeatBax: Quick Export (Last Format)`
+- **Trigger**: Command palette or keybinding
+- **Behavior**: Re-export with the most recently used format without prompting
+- **Implementation**:
+  - Track `lastExportFormat` in `window` or IndexedDB
+  - On invocation, call `onExport(lastExportFormat)` directly
+  - Show toast confirming format used
+  - Fallback to JSON if no history
+- **Keybinding**: Optional (suggest `Ctrl+E` for quick export)
+
+#### 7. Reference & Help
+
+**7.1 Show Effect Presets**
+- **ID**: `beatbax.showEffectPresets`
+- **Label**: `BeatBax: Show Effect Presets`
+- **Trigger**: Command palette or when user types effect name
+- **Behavior**: Quick-pick of common effect presets (vol_slide, trem, arp, etc.) with descriptions
+- **Implementation**:
+  - Build preset list from BeatBax language docs (effects schema)
+  - Show quick-pick with format: `label: "vol_slide(12, down) — volume decrease over 12 ticks"`
+  - On selection, insert at cursor
+- **Keybinding**: Optional
+
+**7.2 Show Syntax Help**
+- **ID**: `beatbax.showSyntaxHelp`
+- **Label**: `BeatBax: Show Syntax Help…`
+- **Trigger**: Command palette or context-sensitive (cursor on keyword)
+- **Behavior**: Show in-editor documentation for pat/seq/inst/channel/effect syntax
+- **Implementation**:
+  - Detect keyword under cursor (pat, seq, inst, etc.)
+  - Show quick-pick of help topics
+  - Display formatted markdown in a webview panel or hover
+  - Include examples for each syntax form
+- **Keybinding**: Optional (suggest `Ctrl+H`)
+
+## Implementation Plan
+
+### Phase 1: Core Navigation (High Priority)
+- Go to Pattern / Sequence / Instrument Definition
+- Find All References
+- List All Definitions
+
+### Phase 2: Audition & Quick Preview (High Priority)
+- Preview Pattern Under Cursor
+- Preview Sequence Under Cursor
+- Play from Cursor Position
+
+### Phase 3: Editing & Organization (Medium Priority)
+- Duplicate Pattern / Sequence
+- Rename Definition (with reference updates)
+- Extract Selection to Pattern
+- Sort Definitions
+
+### Phase 4: Analysis & Diagnostics (Medium Priority)
+- Show Unused Definitions
+- Show Pattern Duration
+- Audit Song for Common Issues
+
+### Phase 5: Channel Operations & Export (Lower Priority)
+- Copy Channel Configuration
+- Swap Channel Assignments
+- Export to Clipboard
+- Quick Export (Last Format)
+- Show Effect Presets
+- Show Syntax Help
+
+### Web UI Changes
+- **command-palette.ts**: Add command registrations and implementations
+- **main.ts**: Wire new commands to playback, editor, and store callbacks
+- **Types**: Define interfaces for command metadata (command group, priority, keybinding)
+
+### Parser / Core Changes
+- **None required** — all commands operate on editor source, not core engine
+
+### Testing Strategy
+
+#### Unit Tests
+- Pattern/sequence detection under cursor
+- Definition extraction and parsing
+- Reference counting (unused definitions)
+- Channel configuration copying
+
+#### Integration Tests
+- Navigation to definitions and back
+- Duplicate with name collision handling
+- Rename with reference update verification
+- Audition playback generation
+
+#### Manual Tests
+- Keybinding conflicts with Monaco / system
+- Quick-pick dismiss on Escape
+- Toast notifications appear/disappear
+- Clipboard operations on all browsers
+
+## Command Registration Reference
+
+All commands follow the Monaco pattern:
+```typescript
+reg({
+  id: 'beatbax.commandId',
+  label: 'BeatBax: Human-Readable Label',
+  keybindings: [/* optional keycodes */],
+  contextMenuGroupId: '9_beatbax', // optional: show in right-click
+  contextMenuOrder: N,             // optional: display order
+  run: () => { /* implementation */ },
+});
+```
+
+### Proposed Keybindings
+
+| Command | Binding | Rationale |
+|---------|---------|-----------|
+| Go to Pattern Def | `Ctrl+Shift+D` | Mnemonic: Definition |
+| Find All References | `Ctrl+Shift+F` | Mnemonic: Find |
+| Rename Definition | `Ctrl+Shift+R` | Mnemonic: Rename |
+| Extract to Pattern | `Ctrl+Shift+E` | Mnemonic: Extract |
+| Preview Pattern | `Alt+P` | Mnemonic: Preview |
+| Play from Cursor | `Alt+Shift+P` | Modifier of Preview |
+| Quick Export | `Ctrl+E` | Quick variant of Export |
+| Show Syntax Help | `Ctrl+H` | Mnemonic: Help |
+
+(All keybindings are optional and should be validated against existing Monaco/VS Code defaults.)
+
+## Migration Path
+
+- **No breaking changes**: All commands are additive
+- **Backward compatible**: Existing exports, validate, and channel commands unchanged
+- **Phased rollout**: Deploy by priority group to gather feedback
+
+## Implementation Checklist
+
+- [ ] Phase 1 navigation commands implemented and tested
+- [ ] Phase 2 audition commands implemented and tested
+- [ ] Phase 3 editing commands implemented and tested
+- [ ] Phase 4 diagnostics commands implemented and tested
+- [ ] Phase 5 convenience commands implemented and tested
+- [ ] Keybinding conflicts resolved
+- [ ] Toast notifications added for user feedback
+- [ ] All commands appear in command palette (F1) and context menu (right-click)
+- [ ] Documentation updated with new commands
+- [ ] Tutorial/quickstart updated with common command workflows
+
+## Future Enhancements
+
+1. **Command Aliases**: Support alternative names for commands (e.g., "Jump to Pattern" → Go to Pattern Def)
+2. **Custom Keybindings**: Allow users to override keybindings in editor settings
+3. **Macro Recording**: Record and replay a sequence of commands for repeated workflows
+4. **Command Palette Grouping**: Collapse/expand command categories in the palette
+5. **Breadcrumb Navigation**: Show full path when jumping between definitions (file → section → definition)
+6. **Multi-file Support**: Extend navigation to imported/included BeatBax files (future feature)
+
+## Open Questions
+
+1. Should "Rename Definition" prompt in-place (Monaco input box) or via quick-pick?
+2. Should "Duplicate Pattern" auto-generate a name or prompt the user?
+3. Should "Play from Cursor" preserve playback state (mute/solo/loop) or restart fresh?
+4. Should "Show Pattern Duration" include tick count and other metadata, or just visual estimate?
+5. Should effect presets be context-sensitive (show only valid effects for current instrument type)?
+
+## References
+
+- [Monaco Editor Action API](https://microsoft.github.io/monaco-editor/docs.html)
+- [BeatBax Language Spec](/docs/language/syntax.md)
+- [BeatBax Command Palette Source](/apps/web-ui/src/editor/command-palette.ts)
+
+## Additional Notes
+
+- Commands are designed to be **keyboard-first** to minimize context-switching during composition
+- All commands should **fail gracefully** (show toast, not throw) if cursor is in invalid context
+- Commands should **preserve undo/redo history** for user-initiated edits (use `editor.executeEdits`)
+- Test with large song files (1000+ patterns) to ensure perf is acceptable

--- a/docs/language/volume-directive.md
+++ b/docs/language/volume-directive.md
@@ -31,7 +31,7 @@ volume 0.5  # Reduce to 50% to prevent clipping in dense mixes
 
 inst lead  type=pulse1 duty=75 env=15,up
 inst bass  type=pulse2 duty=25 env=12,down
-inst wave1 type=wave   wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave   wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst drums type=noise  env=10,down
 
 pat melody = C5:4 E5:4 G5:4 C6:4

--- a/docs/ui/web-ui-syntax-highlighting.md
+++ b/docs/ui/web-ui-syntax-highlighting.md
@@ -74,7 +74,7 @@ volume 80
 
 ```beatbax
 inst leadA type=pulse1 duty=60 env={"level":12,"direction":"down","period":1,"format":"gb"} gm=81
-inst wave1 type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3] gm=82
+inst wave1 type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2] gm=82
 inst snare type=noise gb:width=7 env={"level":12,"direction":"down"} note=C5
 ```
 

--- a/packages/engine/src/chips/gameboy/ui-contributions.ts
+++ b/packages/engine/src/chips/gameboy/ui-contributions.ts
@@ -16,15 +16,15 @@ Exactly 4 channels. Each channel number (1–4) must appear AT MOST ONCE per son
 Channel-to-type mapping is FIXED — you cannot swap these:
   channel 1 → type=pulse1   (melodic) — typically: lead melody
   channel 2 → type=pulse2   (melodic) — typically: harmony, counter-melody, or bass
-  channel 3 → type=wave     (wavetable, no envelope volume) — typically: bass or accompaniment
-  channel 4 → type=noise    (drums/percussion) — typically: kick, snare, hi-hat
+  channel 3 → type=wave     (wavetable, no envelope volume) — typically: bass, kick drum or accompaniment
+  channel 4 → type=noise    (drums/percussion) — typically: snare, hi-hat
 NEVER write two "channel <number> =>" lines. NEVER define instruments inside pat bodies.
 
 INSTRUMENTS  (inst <name> <fields>)
   type=pulse1|pulse2    duty=<12|25|50|75>   env=<0-15>,<up|down|flat>
-  type=wave             wave=[<16 values 0-15>]  (no env)
+  type=wave             wave=[<32 values 0-15>]   volume=<0|25|50|100>
   type=noise            env=<0-15>,<up|down|flat>
-  Extended GB envelope: env=gb:<vol>,<dir>,<period>  e.g. env=gb:12,down,1
+  Extended GB envelope: env=gb:<vol>,<dir>,<period> (pulse/noise only; not wave)
   sweep effect is only valid on channel 1 (pulse1).
   For percussion, define NAMED noise instruments (e.g. kick, snare, hihat) with
   different envelopes to distinguish timbres. You can have multiple noise instruments.`.trim();
@@ -45,42 +45,44 @@ GAME BOY CHIPTUNE STYLE GUIDE (recommendations, not rules)
        effect dom7Arp  = arp:4,7,10    # dominant 7th
      Apply on held notes:  F3<majorArp>:8  G3<minorArp>:8
 
-  2. VIBRATO on sustained melody notes — adds expressiveness to peaks and long holds.
-     Vary depth/speed to differentiate song sections:
+    2. VIBRATO + SHORT ENVELOPES — use vibrato on sustained notes and short punchy
+      envelopes for attack; this combination works very well for expressive leads.
+      Vary depth/speed by section:
        effect wobble  = vib:3,5,sine,3  # gentle wobble on melody peaks
-       effect deepVib = vib:5,2,sine,6  # slow atmospheric vibrato for bridges
-       effect fastVib = vib:2,8,sine,2  # rapid shimmer on climax notes
+       effect deepVib = vib:5,2,sine,6  # slower vibrato for bridges
+       effect fastVib = vib:2,8,sine,2  # shimmer on climactic notes
 
-  3. TREMOLO for shimmer/sparkle effects on climactic notes:
-       effect shimmer = trem:5,8,sine   # fast amplitude flicker — triumphant peaks
-       effect horror  = trem:3,8,square # choppy square-wave tremolo — tense sections
-
-  4. PORTAMENTO / slides for melodic runs and legato bass lines:
+    3. PORTAMENTO / slides for melodic runs and legato bass lines:
        effect slide     = port:10  # snappy slide — ascending scalar runs
        effect slowSlide = port:4   # smooth legato — walking bass lines
      Use on ascending runs:  C4:2 E4<slide>:2 G4<slide>:2 C5<slide>:2
 
-  5. DUTY-CYCLE MODULATION (DCM) — define multiple pulse instruments with different
-     duty values and switch between them inline within a pattern for timbral variety:
-       inst lead_thin  type=pulse1 duty=12 env=gb:13,down,2  # hollow, nasal
-       inst lead_bright type=pulse1 duty=50 env=gb:12,down,3  # balanced, bold
-       inst lead_warm  type=pulse1 duty=75 env=gb:11,down,4  # warm, full
-       pat riff = inst lead_thin C5:2 E5:2 inst lead_bright G5:4 inst lead_warm C6:4
+    4. USE HUGETRACKER-EXPORTABLE FX HEAVILY — prefer panning and volume slide for
+      motion/space that survives UGE export:
+       effect leftPan  = pan:L
+       effect rightPan = pan:R
+       effect swell    = volSlide:+8,4
+       effect fade     = volSlide:-3
 
-  6. FAST 16th-NOTE MELODIES — GB music is characterised by energetic, rapid note
-     sequences. Use short durations (:2 to :4) for melodic runs and fills.
-     Avoid overly long notes unless intentionally atmospheric.
+    5. PULSE-PAIR HARMONY (CH1 + CH2) — let Pulse 1 carry melody and Pulse 2 play
+      harmonizing intervals (3rds, 5ths, 6ths) with contrasting duty cycles.
+      Example timbral split: pulse1 duty=12 (lead), pulse2 duty=75 (harmony).
 
-  7. SHORT, PUNCHY ENVELOPES — fast-decay envelopes give the characteristic bright
-     GB attack. Prefer env=gb:<vol>,down,1 or env=gb:<vol>,down,2 for lead/bass.
-     Slower periods (3–6) for pads and atmospheric sustained notes.
+    6. OCTAVE DOUBLING + CALL/RESPONSE — alternate short phrase answers between ch1/ch2,
+      and use octave doubling in hooks/choruses to widen the line without extra chords.
 
-  8. NAMED PRESETS for all recurring effects — define effect presets at the top of
+    7. WAVE CHANNEL ROLE-SWITCHING — use different wave instruments on channel 3 for
+      different roles (e.g., kick-like wave hit vs bass waveform), switching by section.
+      Layer these with pulse harmony/arpeggios for thicker arrangements.
+
+    8. NAMED PRESETS for all recurring effects — define effect presets at the top of
      the song, before any patterns, and reference them by name throughout.
      This is idiomatic BeatBax style:
        effect wobble   = vib:3,5,sine,3
        effect majorArp = arp:4,7
-       effect slide    = port:10`.trim();
+       effect slide    = port:10
+       effect fade     = volSlide:-3
+       effect leftPan  = pan:L`.trim();
 
 // ─── Hover docs ───────────────────────────────────────────────────────────────
 
@@ -95,7 +97,7 @@ const hoverDocs: Record<string, string> = {
     '**Game Boy instrument types:**',
     '- `type=pulse1` — `duty` (`12`·`25`·`50`·`75`), `env`, `sweep` (pulse1 only); see `env` and `sweep` hovers',
     '- `type=pulse2` — `duty`, `env`; no hardware sweep',
-    '- `type=wave` — `wave` (16 × 0–15 array or 32-nibble hex string), `volume` (`0`·`25`·`50`·`100`); no envelope',
+    '- `type=wave` — `wave` (32 × 0–15 array, 16 × 0–15 array, or 32-nibble hex string), `volume` (`0`·`25`·`50`·`100`); no envelope',
     '- `type=noise` — `env`, `width` (`7` = metallic/tonal · `15` = full/broad)',
     '',
     'Example: `inst lead type=pulse1 duty=50 env=gb:12,down,1`',
@@ -107,7 +109,7 @@ const hoverDocs: Record<string, string> = {
   wave: [
     '**Wave channel** — Game Boy wavetable synthesizer (NR30–NR34 + Wave RAM).',
     'The `wave=` parameter accepts three formats:',
-    '```\n# 16-entry array (0–15 per sample; duplicated to fill 32-nibble Wave RAM on export)\nwave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]\n\n# 32-entry array (full Wave RAM — each value 0–15)\nwave=[9,9,10,12,12,13,14,14,13,12,11,9,8,5,3,4,4,5,6,6,7,7,7,6,6,5,3,4,4,4,5,6]\n\n# 32-nibble hex string (hUGETracker format — one hex digit per nibble)\nwave="0478ABBB986202467776420146777631"\n```',
+    '```\n# 32-entry array (full Wave RAM — each value 0–15)\nwave=[9,9,10,12,12,13,14,14,13,12,11,9,8,5,3,4,4,5,6,6,7,7,7,6,6,5,3,4,4,4,5,6]\n\n# 16-entry array (0–15 per sample; duplicated to fill 32-nibble Wave RAM on export)\nwave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]\n\n# 32-nibble hex string (hUGETracker format — one hex digit per nibble)\nwave="0478ABBB986202467776420146777631"\n```',
     '- Values are **4-bit** (0–15). Values outside this range are clamped on export.',
     '- Maximise peak (near 15) for good perceived loudness; avoid strong DC offset.',
     '- Use `volume=` (`0` · `25` · `50` · `100`) to set the hardware output-level selector.',
@@ -182,8 +184,8 @@ const helpSections: ChipUIContributions['helpSections'] = [
         kind: 'snippet',
         label: 'Wave channel (type=wave)',
         code:
-`inst wv type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
-# wave: 16 nibble values (0-15) defining the 4-bit wavetable`,
+      `inst wv type=wave wave=[9,9,10,12,12,13,14,14,13,12,11,9,8,5,3,4,4,5,6,6,7,7,7,6,6,5,3,4,4,4,5,6]
+    # wave: 32 nibble values (0-15) defining full Wave RAM`,
       },
       {
         kind: 'snippet',

--- a/packages/engine/src/chips/gameboy/ui-contributions.ts
+++ b/packages/engine/src/chips/gameboy/ui-contributions.ts
@@ -107,7 +107,7 @@ const hoverDocs: Record<string, string> = {
   wave: [
     '**Wave channel** — Game Boy wavetable synthesizer (NR30–NR34 + Wave RAM).',
     'The `wave=` parameter accepts three formats:',
-    '```\n# 16-entry array (0–15 per sample; duplicated to fill 32-nibble Wave RAM on export)\nwave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]\n\n# 32-entry array (full Wave RAM — each value 0–15)\nwave=[9,9,10,12,12,13,14,14,13,12,11,9,8,5,3,4,4,5,6,6,7,7,7,6,6,5,3,4,4,4,5,6]\n\n# 32-nibble hex string (hUGETracker format — one hex digit per nibble)\nwave="0478ABBB986202467776420146777631"\n```',
+    '```\n# 16-entry array (0–15 per sample; duplicated to fill 32-nibble Wave RAM on export)\nwave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]\n\n# 32-entry array (full Wave RAM — each value 0–15)\nwave=[9,9,10,12,12,13,14,14,13,12,11,9,8,5,3,4,4,5,6,6,7,7,7,6,6,5,3,4,4,4,5,6]\n\n# 32-nibble hex string (hUGETracker format — one hex digit per nibble)\nwave="0478ABBB986202467776420146777631"\n```',
     '- Values are **4-bit** (0–15). Values outside this range are clamped on export.',
     '- Maximise peak (near 15) for good perceived loudness; avoid strong DC offset.',
     '- Use `volume=` (`0` · `25` · `50` · `100`) to set the hardware output-level selector.',
@@ -182,7 +182,7 @@ const helpSections: ChipUIContributions['helpSections'] = [
         kind: 'snippet',
         label: 'Wave channel (type=wave)',
         code:
-`inst wv type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+`inst wv type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 # wave: 16 nibble values (0-15) defining the 4-bit wavetable`,
       },
       {
@@ -256,7 +256,7 @@ time 4
 
 inst lead  type=pulse1 duty=50  env=12,down
 inst bass  type=pulse2 duty=25  env=10,down
-inst wave1 type=wave   wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave   wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst kick  type=noise  env=12,down
 
 pat melody  = C5 E5 G5 C6

--- a/packages/engine/tests/instrument-serialization.test.ts
+++ b/packages/engine/tests/instrument-serialization.test.ts
@@ -33,7 +33,7 @@ channel 1 => inst lead seq main
   test('parses instruments with array values', () => {
     const src = `
 chip gameboy
-inst wave1 type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 pat a = C5
 channel 3 => inst wave1 seq main
     `;

--- a/packages/engine/tests/phase2.5-position-tracking.test.ts
+++ b/packages/engine/tests/phase2.5-position-tracking.test.ts
@@ -295,7 +295,7 @@ bpm 240
 
 inst lead type=pulse1 duty=50 env=12,down
 inst bass type=pulse2 duty=25 env=10,down
-inst wave1 type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst snare type=noise env=12,down
 
 pat melody = C5 E5 G5 C6

--- a/packages/engine/tests/resolver.nested-imports.test.ts
+++ b/packages/engine/tests/resolver.nested-imports.test.ts
@@ -17,13 +17,13 @@ describe('Nested Import Resolution', () => {
     //     sounds/
     //       drums.ins -> imports "local:base.ins" (sibling file)
     //       base.ins
-    
+
     const mockFileSystem = {
       '/project/main.bax': 'import "local:lib/sounds/drums.ins"',
       '/project/lib/sounds/drums.ins': 'import "local:base.ins"\ninst kick type=noise env=12,down',
       '/project/lib/sounds/base.ins': 'inst snare type=noise env=8,down',
     };
-    
+
     const ast: AST = {
       imports: [{ source: 'local:lib/sounds/drums.ins' }],
       insts: {},
@@ -55,14 +55,14 @@ describe('Nested Import Resolution', () => {
     //       sub.ins
     //     effects/
     //       reverb.ins
-    
+
     const mockFileSystem = {
       '/project/main.bax': 'import "local:lib/presets.ins"',
       '/project/lib/presets.ins': 'import "local:bass/sub.ins"\nimport "local:effects/reverb.ins"\ninst lead type=pulse1 duty=50',
       '/project/lib/bass/sub.ins': 'inst bass type=pulse2 duty=25',
-      '/project/lib/effects/reverb.ins': 'inst pad type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]',
+      '/project/lib/effects/reverb.ins': 'inst pad type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]',
     };
-    
+
     const ast: AST = {
       imports: [{ source: 'local:lib/presets.ins' }],
       insts: {},
@@ -86,13 +86,13 @@ describe('Nested Import Resolution', () => {
   test('throws error when nested import uses wrong relative path', async () => {
     // This test demonstrates that imports resolve relative to the importing file,
     // not the original song file
-    
+
     const mockFileSystem = {
       '/project/main.bax': 'import "local:lib/child.ins"',
       '/project/lib/child.ins': 'import "local:lib/parent.ins"', // Wrong! Should be "local:parent.ins"
       '/project/lib/parent.ins': 'inst base type=pulse1',
     };
-    
+
     const ast: AST = {
       imports: [{ source: 'local:lib/child.ins' }],
       insts: {},

--- a/songs/gameboy/instruments/gb_instrument_demo.bax
+++ b/songs/gameboy/instruments/gb_instrument_demo.bax
@@ -58,15 +58,15 @@ inst wave_quiet type=wave wave=[8,9,10,12,13,14,14,15,15,15,14,14,13,12,10,9,8,6
 inst wave_mute  type=wave wave=[8,9,10,12,13,14,14,15,15,15,14,14,13,12,10,9,8,6,5,3,2,1,1,0,0,0,1,1,2,3,5,6] volume=0  gm=82
 
 # Harmonic-rich waveforms
-inst wave_triangle type=wave wave=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,15,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1] gm=82
+inst wave_triangle type=wave wave=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0] gm=82
 inst wave_pulse25  type=wave wave=[15,15,15,15,15,15,15,15,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0] gm=81
 inst wave_pulse12  type=wave wave=[15,15,15,15,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0] gm=80
 
 # Complex/musical waveforms
-inst wave_organ type=wave wave=[8,10,12,14,15,14,13,11,8,6,3,2,0,1,2,5,8,10,12,14,15,14,13,11,8,6,3,2,0,1,2,5] gm=16
-inst wave_strings type=wave wave=[0,2,4,6,8,10,11,12,13,14,14,14,13,12,11,10,8,6,4,2,0,2,4,6,8,10,11,12,13,14,14,14] gm=49
-inst wave_brass type=wave wave=[8,11,13,14,15,15,14,12,10,8,5,4,2,2,1,5,8,11,13,14,15,15,14,12,10,8,5,4,2,2,1,5] gm=57
-inst wave_bell type=wave wave=[15,15,14,13,12,11,9,8,6,5,3,2,1,1,0,0,0,1,1,2,3,5,6,8,9,11,12,13,14,15,15,15] gm=14
+inst wave_organ type=wave wave=[8,10,12,14,15,14,13,11,8,6,3,2,0,1,2,5,8,10,12,14,15,14,13,11,8,6,3,2,0,1,2,5] gm=16  # NOTE: contains 2 cycles per buffer (16-sample repeat) — pitch sounds one octave higher than a 32-sample single-cycle waveform; intentional for organ harmonic richness
+inst wave_strings type=wave wave=[0,2,4,6,8,10,11,12,13,14,14,14,13,12,11,10,8,6,4,2,0,2,4,6,8,10,11,12,11,9,6,2] gm=49
+inst wave_brass type=wave wave=[8,11,13,14,15,15,14,12,10,8,5,4,2,2,1,5,8,11,13,14,15,15,14,12,10,8,5,4,2,2,1,5] gm=57  # NOTE: contains 2 cycles per buffer (16-sample repeat) — pitch sounds one octave higher than a 32-sample single-cycle waveform; intentional for brass harmonic richness
+inst wave_bell type=wave wave=[15,15,14,14,13,12,10,9,8,6,5,3,2,1,1,0,0,0,1,1,2,3,5,6,8,9,10,12,13,14,14,15] gm=14
 
 # Experimental/effect waveforms
 inst wave_metallic type=wave wave=[15,8,0,6,12,8,3,6,9,8,6,6,6,8,9,6,3,8,12,6,0,8,15,8,0,6,12,8,3,6,9,12] gm=122

--- a/songs/gameboy/instruments/gb_wave_scan_demo.bax
+++ b/songs/gameboy/instruments/gb_wave_scan_demo.bax
@@ -1,0 +1,107 @@
+## gb_wave_scan_demo.bax
+## Wave-channel instrument morphing demo using per-tick instrument retriggers.
+##
+## Goal:
+## - Demonstrate pseudo-wavetable scanning on GB channel 3 by switching between
+##   predefined wave instruments every new note trigger.
+## - Show attack -> body -> decay timbre transitions, vowel-style morphing,
+##   metallic sweeps, and wave+noise hybrid percussion.
+##
+## Notes:
+## - GB wave RAM cannot be rewritten mid-note in this model.
+## - Each new note trigger can select a different wave instrument, which gives
+##   a practical "scan" effect when sequenced at short tick intervals.
+
+song name "Wave Scan Morphing Demo"
+song artist "The BeatBax Team"
+song description "Demonstrates expressive Game Boy wave-channel pseudo-wavetable scanning via rapid per-tick instrument switching: attack-body-decay bass, ah-oh-uh vowel morphing, metallic sweep, bell morph, and wave+noise hybrid drum layering."
+song tags "gameboy,wave,scan,morphing,advanced,instruments,demo"
+
+chip gameboy
+bpm 156
+time 4
+
+# =============================================================================
+# INSTRUMENTS
+# =============================================================================
+
+# Pulse support layers
+inst fmish_fund type=pulse1 duty=25 env={"level":12,"direction":"down","period":2,"format":"gb"} gm=81
+inst pad_soft   type=pulse2 duty=50 env={"level":8,"direction":"down","period":4,"format":"gb"} gm=89
+
+# Wave instruments used for rapid timbre switching
+inst w_click       type=wave wave=[8,9,10,11,12,12,11,10,9,8,7,6,5,5,6,7,8,8,8,8,7,7,6,6,5,5,6,7,8,9,9,8] volume=25 gm=34
+inst w_body_round  type=wave wave=[8,9,10,12,13,14,14,15,15,15,14,14,13,12,10,9,8,6,5,3,2,1,1,0,0,0,1,1,2,3,5,6] volume=100 gm=38
+inst w_decay_dark  type=wave wave=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0] volume=25 gm=39
+
+inst w_vowel_ah    type=wave wave=[8,10,12,14,15,14,13,11,8,6,3,2,0,1,2,5,8,10,12,14,15,14,13,11,8,6,3,2,0,1,2,5] volume=100 gm=53
+inst w_vowel_oh    type=wave wave=[0,2,4,6,8,10,11,12,13,14,14,14,13,12,11,10,8,6,4,2,0,2,4,6,8,10,11,12,11,9,6,2] volume=100 gm=54
+inst w_vowel_uh    type=wave wave=[8,11,13,14,15,15,14,12,10,8,5,4,2,2,1,5,8,11,13,14,15,15,14,12,10,8,5,4,2,2,1,5] volume=50 gm=55
+
+inst w_metal_a     type=wave wave=[15,8,0,6,12,8,3,6,9,8,6,6,6,8,9,6,3,8,12,6,0,8,15,8,0,6,12,8,3,6,9,12] volume=100 gm=30
+inst w_metal_b     type=wave wave=[15,15,15,13,10,10,10,8,5,5,5,3,0,0,0,0,0,3,5,5,5,8,10,10,10,13,15,15,15,8,0,8] volume=50 gm=31
+
+inst w_bell_simple  type=wave wave=[8,9,10,12,13,14,14,15,15,15,14,14,13,12,10,9,8,6,5,3,2,1,1,0,0,0,1,1,2,3,5,6] volume=100 gm=14
+inst w_bell_complex type=wave wave=[15,15,14,14,13,12,10,9,8,6,5,3,2,1,1,0,0,0,1,1,2,3,5,6,8,9,10,12,13,14,14,15] volume=50 gm=15
+
+inst w_snare_attack type=wave wave=[8,5,2,8,13,9,5,8,11,6,1,8,14,11,7,8,9,7,4,8,12,9,6,8,10,7,3,9,15,8,0,4] volume=100 gm=121
+inst w_snare_tail   type=wave wave=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0] volume=25 gm=120
+
+# Noise support for hybrid percussion
+inst n_kick   type=noise env={"level":14,"direction":"down","period":1,"format":"gb"} note=C5
+inst n_snare  type=noise env={"level":10,"direction":"down","period":2,"format":"gb"} note=C6
+inst n_click  type=noise env={"level":6,"direction":"down","period":1,"format":"gb"} note=C7
+
+# =============================================================================
+# EFFECT PRESETS
+# =============================================================================
+effect quickVib = vib:2,4,sine,2
+effect glide    = port:8
+
+# =============================================================================
+# PATTERNS
+# =============================================================================
+
+# 1) Attack -> body -> decay bass morph.
+# Every step retriggers the same pitch with a different wave instrument.
+pat bass_scan_pat = inst w_click C3 inst w_body_round C3:3 inst w_click G2 inst w_body_round G2:3 inst w_click A2 inst w_body_round A2:3 inst w_click C3 inst w_body_round C3:3
+
+# 2) Vowel-style morph: ah -> oh -> uh across very short note triggers.
+pat vowel_scan_pat = inst w_vowel_ah C5 inst w_vowel_oh C5 inst w_vowel_uh C5 inst w_vowel_oh C5 inst w_vowel_ah E5 inst w_vowel_oh E5 inst w_vowel_uh E5 inst w_vowel_oh E5 inst w_vowel_ah G5<quickVib> inst w_vowel_oh G5 inst w_vowel_uh G5 inst w_vowel_oh G5 inst w_vowel_ah C6 inst w_vowel_oh C6 inst w_vowel_uh C6 inst w_vowel_oh C6
+
+# 3) Metallic scan: two harsh waves alternating each tick with a slide contour.
+pat metal_scan_pat = inst w_metal_a C5<glide> inst w_metal_b D5<glide> inst w_metal_a E5<glide> inst w_metal_b F5<glide> inst w_metal_a G5<glide> inst w_metal_b A5<glide> inst w_metal_a B5<glide> inst w_metal_b C6 inst w_metal_a B5 inst w_metal_b A5 inst w_metal_a G5 inst w_metal_b F5 inst w_metal_a E5 inst w_metal_b D5 inst w_metal_a C5 .
+
+# 4) Bell morph: simple sine-ish onset -> richer harmonic body.
+pat bell_morph_pat = inst w_bell_simple C5 inst w_bell_simple G5 inst w_bell_complex C6 inst w_bell_complex G5 inst w_bell_simple E5 inst w_bell_complex D5 inst w_bell_simple C5 . inst w_bell_simple G4 inst w_bell_complex C5 inst w_bell_complex E5 inst w_bell_simple G5 inst w_bell_complex C6 inst w_bell_simple G5 inst w_bell_complex E5 .
+
+# 5) Wave snare tail layer: noisy attack then tonal tail on the wave channel.
+pat wave_snare_layer_pat = . . . . inst w_snare_attack C4 inst w_snare_tail C4 . . . . . inst w_snare_attack C4 inst w_snare_tail C4 . . .
+
+# Pulse support (fundamental + harmony for context)
+pat pulse_lead_pat = C5 . G4 . A4 . C5 . E5 . D5 . C5 . G4 .
+pat pulse_pad_pat  = C4:4 G3:4 A3:4 C4:4
+
+# Noise support groove
+pat noise_hybrid_pat = C5 . . C7 C6 . C7 . C5 . . C7 C6 . C7 .
+
+# =============================================================================
+# SEQUENCES
+# =============================================================================
+seq wave_showcase_seq = bass_scan_pat vowel_scan_pat metal_scan_pat bell_morph_pat wave_snare_layer_pat
+seq pulse_lead_seq    = pulse_lead_pat pulse_lead_pat pulse_lead_pat pulse_lead_pat pulse_lead_pat
+seq pulse_pad_seq     = pulse_pad_pat pulse_pad_pat pulse_pad_pat pulse_pad_pat pulse_pad_pat
+seq noise_seq         = noise_hybrid_pat noise_hybrid_pat noise_hybrid_pat noise_hybrid_pat noise_hybrid_pat
+
+# =============================================================================
+# CHANNEL ASSIGNMENTS
+# =============================================================================
+channel 1 => inst fmish_fund  seq pulse_lead_seq
+channel 2 => inst pad_soft    seq pulse_pad_seq
+channel 3 => inst w_body_round seq wave_showcase_seq
+channel 4 => inst n_kick      seq noise_seq
+
+# =============================================================================
+# PLAYBACK
+# =============================================================================
+play auto repeat

--- a/tests/phase2.5-position-tracking.test.ts
+++ b/tests/phase2.5-position-tracking.test.ts
@@ -295,7 +295,7 @@ bpm 240
 
 inst lead type=pulse1 duty=50 env=12,down
 inst bass type=pulse2 duty=25 env=10,down
-inst wave1 type=wave wave=[0,3,6,9,12,9,6,3,0,3,6,9,12,9,6,3]
+inst wave1 type=wave wave=[0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2,0,2,3,5,6,8,9,11,12,11,9,8,6,5,3,2]
 inst snare type=noise env=12,down
 
 pat melody = C5 E5 G5 C6


### PR DESCRIPTION
<!-- Describe the purpose of this PR and the changes it makes. -->

### Summary

- add Monaco hover previews for wave tables, GB envelopes, and NES macro envelopes
- suppress instrument/effect hover and semantic coloring inside metadata strings
- improve pattern grid with global playhead, labeled segments, AST-aware sequence expansion, and smoother cursor updates
- split glyph-margin channel controls into left mute and right solo lanes
- enforce mute/solo state consistency (solo auto-unmutes, mute auto-unsolos)
- refine song visualizer and centered menu-bar song title layout
- update sample wave snippets to 32-sample forms across docs, help text, and tests
- add waveform validation fixes to GB instrument demo and add advanced wave-scan example song
- expand tests for hover behavior, glyph margin lanes, and channel mixer/visualizer mute-solo interactions

### Checklist

- [X] My changes add required tests and they pass.
- [X] I ran `npm test` locally and all tests passed.
- [X] I updated README or docs if required.
- [X] This PR follows repository coding style and guidelines.

### Notes for reviewers

None.
