### PR TITLE
feat(web-ui): instrument hovers, MIDI preview, and editor UX polish

### DIFF
--- a/.changeset/web-ui-song-editing-hovers.md
+++ b/.changeset/web-ui-song-editing-hovers.md
@@ -1,0 +1,30 @@
+---
+"@beatbax/engine": patch
+"@beatbax/plugin-chip-sms": patch
+"@beatbax/plugin-chip-spectrum-128": patch
+---
+
+Web UI song-editing polish: chip-aware instrument hovers, MIDI idle preview, editor UX improvements, and parser validation fixes.
+
+### @beatbax/web-ui _(not versioned — local app)_
+
+- **Instrument hovers** on `inst` lines: GM program names (`gm=`), percussion/melodic `note=`, and chip-aware property keywords/values (`type`, `vol`, `duty`, `noise_mode`, `noise_rate`, `chipRegion`, etc.). Property parsing preserves camelCase keys; chip-provided docs show on string enum values (e.g. `chipRegion=cpc`).
+- **SMS `vol_env` sparklines** now show perceived loudness (attenuation inverted: 0 = loudest, 15 = silent).
+- **MIDI step entry** previews notes on the idle keyboard without arming Record; audition runs after a successful insert; parse fallback when the pattern grid is empty.
+- **Editor UX**: persistent fold-comments setting; View menu and toolbar polish for word-wrap and fold toggles; channel mixer mock/test alignment for built-in NES per-channel volume.
+- **Tests** updated for renamed settings keys (`CHANNEL_MIXER`), event-bus payloads, hover column positions, and quick-fix titles.
+- Add feature design doc: `docs/features/virtual-piano-keyboard.md`.
+
+### @beatbax/engine
+
+- Add NES `hoverDocs` entries for `type`, `duty`, and `vol` (keyword hovers in the web editor).
+- **Parser:** resolve unknown `chip` via `chipRegistry.has()` and skip Game Boy instrument validation when the chip is unknown, avoiding misleading cascade errors (e.g. NES-only types flagged on a typo'd chip name).
+- Regression test: unknown chip reports only the chip error, not spurious instrument type/property warnings.
+
+### @beatbax/plugin-chip-sms
+
+- Add `hoverDocs` for `type` and `vol` (SMS attenuation semantics documented for editor hovers).
+
+### @beatbax/plugin-chip-spectrum-128
+
+- Add `hoverDocs` for `type` and per-channel `tone1` / `tone2` / `tone3` (editor keyword and value hovers).

--- a/apps/web-ui/src/editor/beatbax-language.ts
+++ b/apps/web-ui/src/editor/beatbax-language.ts
@@ -17,6 +17,9 @@ import {
   CHIP_INSTRUMENT_META,
   INST_PROPERTY_NAME_PATTERN,
 } from './instrument-meta';
+import { buildGmHoverMarkdown, parseGmAtPosition } from './gm-programs';
+import { buildNoteHoverMarkdown, parseNoteAtPosition } from './inst-note-hover';
+import { buildInstPropertyHover, buildInstPropertyKeywordHover } from './inst-property-hover';
 
 let latestAST: any = null;
 /** AST with import instruments merged (when imports resolve successfully). */
@@ -365,6 +368,33 @@ export function renderEnvelopeSparkline(levels: number[]): string {
     .join('');
 }
 
+function buildGmHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): monaco.languages.Hover | null {
+  const parsed = parseGmAtPosition(model, position);
+  if (!parsed) return null;
+
+  return {
+    range: parsed.range,
+    contents: [{ value: buildGmHoverMarkdown(parsed.program) }],
+  };
+}
+
+function buildNoteHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+  chip: string,
+): monaco.languages.Hover | null {
+  const parsed = parseNoteAtPosition(model, position);
+  if (!parsed) return null;
+
+  return {
+    range: parsed.range,
+    contents: [{ value: buildNoteHoverMarkdown(parsed, chip) }],
+  };
+}
+
 function buildEnvelopeHover(
   model: monaco.editor.ITextModel,
   position: monaco.IPosition,
@@ -484,6 +514,17 @@ export function renderNesMacroSparkline(values: number[], min: number, max: numb
     .join('');
 }
 
+/**
+ * SMS/SN76489 attenuation sparkline — bar height = perceived loudness.
+ * Attenuation 0 (loudest) → full block; 15 (silent) → empty.
+ */
+export function renderAttenuationSparkline(attenuationLevels: number[]): string {
+  const loudness = attenuationLevels.map((v) =>
+    Math.max(0, Math.min(15, 15 - Math.round(v))),
+  );
+  return renderNesMacroSparkline(loudness, 0, 15);
+}
+
 const DUTY_INDEX_LABELS = ['12.5%', '25%', '50%', '75%'];
 
 function buildNesMacroHover(
@@ -508,9 +549,9 @@ function buildNesMacroHover(
   switch (macro.macroType) {
     case 'vol_env': {
       const clamped = macro.values.map((v) => Math.max(0, Math.min(15, Math.round(v))));
-      sparkline = renderNesMacroSparkline(clamped, 0, 15);
       const lo = Math.min(...clamped), hi = Math.max(...clamped);
       if (canonicalChip === 'spectrum-128') {
+        sparkline = renderNesMacroSparkline(clamped, 0, 15);
         title = '**vol_env** — Hardware envelope program (AY R11–R13)';
         meta = [
           `Levels: **${clamped.length}**  Range: **${lo}–${hi}** / 15`,
@@ -519,9 +560,19 @@ function buildNesMacroHover(
           loopStr,
         ].join('  \n');
       } else if (canonicalChip === 'nes') {
+        sparkline = renderNesMacroSparkline(clamped, 0, 15);
         title = '**Volume envelope** (NES/Famicom software macro, per-frame, 0–15)';
         meta = `Frames: **${clamped.length}**  Range: **${lo}–${hi}** / 15  \n${loopStr}`;
+      } else if (canonicalChip === 'sms') {
+        sparkline = renderAttenuationSparkline(clamped);
+        title = '**vol_env** — SMS volume macro (per-frame attenuation, 0–15)';
+        meta = [
+          `Frames: **${clamped.length}**  Range: **${lo}–${hi}** / 15`,
+          '**0 = loudest** · **15 = silent** — sparkline shows perceived loudness',
+          loopStr,
+        ].join('  \n');
       } else {
+        sparkline = renderNesMacroSparkline(clamped, 0, 15);
         title = '**Volume envelope** (software macro, per-frame, 0–15)';
         meta = `Frames: **${clamped.length}**  Range: **${lo}–${hi}** / 15  \n${loopStr}`;
       }
@@ -930,6 +981,18 @@ export function registerBeatBaxLanguage(): void {
 
       const envelopeHover = buildEnvelopeHover(model, position);
       if (envelopeHover) return envelopeHover;
+
+      const gmHover = buildGmHover(model, position);
+      if (gmHover) return gmHover;
+
+      const noteHover = buildNoteHover(model, position, latestChip);
+      if (noteHover) return noteHover;
+
+      const instPropertyKeywordHover = buildInstPropertyKeywordHover(model, position, latestChip);
+      if (instPropertyKeywordHover) return instPropertyKeywordHover;
+
+      const instPropertyHover = buildInstPropertyHover(model, position, latestChip);
+      if (instPropertyHover) return instPropertyHover;
 
       const nesMacroHover = buildNesMacroHover(model, position, latestChip);
       if (nesMacroHover) return nesMacroHover;
@@ -1428,6 +1491,44 @@ export function registerBeatBaxLanguage(): void {
       if (doc) {
         return {
           contents: [{ value: doc }],
+        };
+      }
+
+      if (
+        word.word === 'gm'
+        && /^\s*inst\s+/.test(lineText)
+        && !lineText.slice(word.startColumn - 1).match(/^gm\s*=/)
+      ) {
+        return {
+          contents: [{
+            value: [
+              '**gm** — General MIDI program number (**0–127**) for MIDI export.',
+              '',
+              'Sets the Program Change message used when this instrument is exported to MIDI.',
+              'Hover a value like `gm=81` to see the patch name.',
+              '',
+              'Example: `inst lead type=pulse1 duty=50 gm=81`',
+            ].join('\n'),
+          }],
+        };
+      }
+
+      if (
+        word.word === 'note'
+        && /^\s*inst\s+/.test(lineText)
+        && !lineText.slice(word.startColumn - 1).match(/^note\s*=/)
+      ) {
+        return {
+          contents: [{
+            value: [
+              '**note** — default pitch for named hit tokens on this instrument.',
+              '',
+              'When a pattern uses the instrument name directly (`kick`, `snare`, `hihat`, …), playback and export use this note instead of requiring an explicit pitch in the pattern.',
+              'Hover a value like `note=C7` to see MIDI number, frequency, and export mapping.',
+              '',
+              'Example: `inst snare type=noise gb:width=7 env=13,down note=C7`',
+            ].join('\n'),
+          }],
         };
       }
 

--- a/apps/web-ui/src/editor/codelens-preview.ts
+++ b/apps/web-ui/src/editor/codelens-preview.ts
@@ -21,7 +21,7 @@
  */
 
 import * as monaco from 'monaco-editor';
-import { parse } from '@beatbax/engine/parser';
+import { parse, parseWithPeggy } from '@beatbax/engine/parser';
 import { resolveSong } from '@beatbax/engine/song';
 import { Player } from '@beatbax/engine/audio/playback';
 import { chipRegistry } from '@beatbax/engine/chips';
@@ -89,6 +89,21 @@ export function resolveAuditionInstrumentForLine(lineText: string, ast: any): st
   if (!patMatch) return null;
 
   return resolvePreviewInstrument(patMatch[1], ast);
+}
+
+/**
+ * Parse source for preview/audition playback. Unlike `parse()`, tolerates recoverable
+ * syntax errors (e.g. empty `pat foo =`) when instruments/chip are still available.
+ */
+export function parseSourceForPreview(source: string): any | null {
+  const result = parseWithPeggy(source);
+  if (!result.hasErrors) return result.ast;
+
+  const ast = result.ast;
+  const hasInsts = ast?.insts && Object.keys(ast.insts).length > 0;
+  const hasChip = Boolean(ast?.chip);
+  if (hasInsts || hasChip) return ast;
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -591,7 +606,7 @@ let _commandsRegistered = false;
 // ---------------------------------------------------------------------------
 let _sharedCtx: any = null;
 
-function ensureAudioCtxReady(): void {
+export function ensureAudioCtxReady(): void {
   const Ctor = typeof window !== 'undefined'
     ? ((window as any).AudioContext ?? (window as any).webkitAudioContext)
     : null;
@@ -718,8 +733,8 @@ export function setupCodeLensPreview(
   };
 
   _stepEntryAuditionTrigger = async (lineText: string, note: string) => {
-    let rawAst: any;
-    try { rawAst = parse(getSource()); } catch { return; }
+    const rawAst = parseSourceForPreview(getSource());
+    if (!rawAst) return;
 
     const instName = resolveAuditionInstrumentForLine(lineText, rawAst);
     if (!instName) return;
@@ -1042,4 +1057,8 @@ export function setupCodeLensPreview(
 
 export function triggerStepEntryAudition(lineText: string, note: string): void {
   _stepEntryAuditionTrigger?.(lineText, note);
+}
+
+export function triggerEffectPreview(effectName: string): void {
+  _effectPreviewTrigger?.(effectName);
 }

--- a/apps/web-ui/src/editor/gm-programs.ts
+++ b/apps/web-ui/src/editor/gm-programs.ts
@@ -1,0 +1,232 @@
+/**
+ * General MIDI program names (GM Level 1, programs 0–127).
+ * Used by editor hovers and completion hints for `gm=` on instrument lines.
+ */
+
+import type * as monaco from 'monaco-editor';
+
+/** Standard GM Level 1 patch names. Index = program number. */
+export const GM_PROGRAM_NAMES: readonly string[] = [
+  'Acoustic Grand Piano',
+  'Bright Acoustic Piano',
+  'Electric Grand Piano',
+  'Honky-tonk Piano',
+  'Electric Piano 1',
+  'Electric Piano 2',
+  'Harpsichord',
+  'Clavinet',
+  'Celesta',
+  'Glockenspiel',
+  'Music Box',
+  'Vibraphone',
+  'Marimba',
+  'Xylophone',
+  'Tubular Bells',
+  'Dulcimer',
+  'Drawbar Organ',
+  'Percussive Organ',
+  'Rock Organ',
+  'Church Organ',
+  'Reed Organ',
+  'Accordion',
+  'Harmonica',
+  'Tango Accordion',
+  'Acoustic Guitar (nylon)',
+  'Acoustic Guitar (steel)',
+  'Electric Guitar (jazz)',
+  'Electric Guitar (clean)',
+  'Electric Guitar (muted)',
+  'Overdriven Guitar',
+  'Distortion Guitar',
+  'Guitar Harmonics',
+  'Acoustic Bass',
+  'Electric Bass (finger)',
+  'Electric Bass (pick)',
+  'Fretless Bass',
+  'Slap Bass 1',
+  'Slap Bass 2',
+  'Synth Bass 1',
+  'Synth Bass 2',
+  'Violin',
+  'Viola',
+  'Cello',
+  'Contrabass',
+  'Tremolo Strings',
+  'Pizzicato Strings',
+  'Orchestral Harp',
+  'Timpani',
+  'String Ensemble 1',
+  'String Ensemble 2',
+  'Synth Strings 1',
+  'Synth Strings 2',
+  'Choir Aahs',
+  'Voice Oohs',
+  'Synth Voice',
+  'Orchestra Hit',
+  'Trumpet',
+  'Trombone',
+  'Tuba',
+  'Muted Trumpet',
+  'French Horn',
+  'Brass Section',
+  'Synth Brass 1',
+  'Synth Brass 2',
+  'Soprano Sax',
+  'Alto Sax',
+  'Tenor Sax',
+  'Baritone Sax',
+  'Oboe',
+  'English Horn',
+  'Bassoon',
+  'Clarinet',
+  'Piccolo',
+  'Flute',
+  'Recorder',
+  'Pan Flute',
+  'Blown Bottle',
+  'Shakuhachi',
+  'Whistle',
+  'Ocarina',
+  'Lead 1 (square)',
+  'Lead 2 (sawtooth)',
+  'Lead 3 (calliope)',
+  'Lead 4 (chime)',
+  'Lead 5 (charang)',
+  'Lead 6 (voice)',
+  'Lead 7 (fifths)',
+  'Lead 8 (bass + lead)',
+  'Pad 1 (new age)',
+  'Pad 2 (warm)',
+  'Pad 3 (polysynth)',
+  'Pad 4 (choir)',
+  'Pad 5 (bowed)',
+  'Pad 6 (metallic)',
+  'Pad 7 (halo)',
+  'Pad 8 (sweep)',
+  'FX 1 (rain)',
+  'FX 2 (soundtrack)',
+  'FX 3 (crystal)',
+  'FX 4 (atmosphere)',
+  'FX 5 (brightness)',
+  'FX 6 (goblins)',
+  'FX 7 (echoes)',
+  'FX 8 (sci-fi)',
+  'Sitar',
+  'Banjo',
+  'Shamisen',
+  'Koto',
+  'Kalimba',
+  'Bag pipe',
+  'Fiddle',
+  'Shanai',
+  'Tinkle Bell',
+  'Agogo',
+  'Steel Drums',
+  'Woodblock',
+  'Taiko Drum',
+  'Melodic Tom',
+  'Synth Drum',
+  'Reverse Cymbal',
+  'Guitar Fret Noise',
+  'Breath Noise',
+  'Seashore',
+  'Bird Tweet',
+  'Telephone Ring',
+  'Helicopter',
+  'Applause',
+  'Gunshot',
+];
+
+const GM_FAMILY_RANGES: ReadonlyArray<{ max: number; label: string }> = [
+  { max: 7, label: 'Piano' },
+  { max: 15, label: 'Chromatic Percussion' },
+  { max: 23, label: 'Organ' },
+  { max: 31, label: 'Guitar' },
+  { max: 39, label: 'Bass' },
+  { max: 47, label: 'Strings' },
+  { max: 55, label: 'Ensemble' },
+  { max: 63, label: 'Brass' },
+  { max: 71, label: 'Reed' },
+  { max: 79, label: 'Pipe' },
+  { max: 87, label: 'Synth Lead' },
+  { max: 95, label: 'Synth Pad' },
+  { max: 103, label: 'Synth Effects' },
+  { max: 111, label: 'Ethnic' },
+  { max: 119, label: 'Percussive' },
+  { max: 127, label: 'Sound Effects' },
+];
+
+export function getGmProgramName(program: number): string | null {
+  if (!Number.isInteger(program) || program < 0 || program > 127) return null;
+  return GM_PROGRAM_NAMES[program] ?? null;
+}
+
+export function getGmProgramFamily(program: number): string | null {
+  if (!Number.isInteger(program) || program < 0 || program > 127) return null;
+  return GM_FAMILY_RANGES.find((entry) => program <= entry.max)?.label ?? null;
+}
+
+export interface ParsedGmProgram {
+  program: number;
+  range: monaco.IRange;
+}
+
+/** Parse `gm=<0-127>` when the cursor is on an instrument definition line. */
+export function parseGmAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): ParsedGmProgram | null {
+  const line = model.getLineContent(position.lineNumber);
+  if (!/^\s*inst\s+/.test(line)) return null;
+
+  const col0 = position.column - 1;
+  const re = /\bgm\s*=\s*(\d+)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(line)) !== null) {
+    const tokenStart = match.index;
+    const tokenEnd = match.index + match[0].length;
+    if (col0 < tokenStart || col0 >= tokenEnd) continue;
+
+    const program = Number.parseInt(match[1], 10);
+    if (Number.isNaN(program)) continue;
+
+    return {
+      program,
+      range: {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: tokenStart + 1,
+        endColumn: tokenEnd + 1,
+      },
+    };
+  }
+
+  return null;
+}
+
+export function buildGmHoverMarkdown(program: number): string {
+  const name = getGmProgramName(program);
+  const family = getGmProgramFamily(program);
+
+  const lines = [
+    '**General MIDI program** — sets the Program Change sent on MIDI export.',
+    '',
+  ];
+
+  if (name) {
+    lines.push(`Program **${program}**: ${name}`);
+    if (family) lines.push(`Family: **${family}**`);
+  } else {
+    lines.push(`Program **${program}** is out of range — use **0–127**.`);
+  }
+
+  lines.push(
+    '',
+    'If `gm=` is omitted, the exporter picks a default based on instrument type (e.g. pulse1 → Lead 1).',
+    '',
+    'Example: `inst lead type=pulse1 duty=50 gm=81`',
+  );
+
+  return lines.join('\n');
+}

--- a/apps/web-ui/src/editor/inst-note-hover.ts
+++ b/apps/web-ui/src/editor/inst-note-hover.ts
@@ -1,0 +1,213 @@
+/**
+ * Hover helpers for `note=` on instrument definition lines.
+ * Explains default hit pitch for named percussion tokens (kick, snare, …).
+ */
+
+import type * as monaco from 'monaco-editor';
+
+const NOTE_SEMITONES: Record<string, number> = {
+  C: 0, 'C#': 1, DB: 1, D: 2, 'D#': 3, EB: 3,
+  E: 4, F: 5, 'F#': 6, GB: 6, G: 7, 'G#': 8, AB: 8,
+  A: 9, 'A#': 10, BB: 10, B: 11,
+};
+
+function noteToMidi(note: string): number | null {
+  const m = note.match(/^([A-G])([#bB]?)(-?\d+)$/i);
+  if (!m) return null;
+  const letter = m[1].toUpperCase();
+  const acc = m[2] ? (m[2].toLowerCase() === 'b' ? 'B' : '#') : '';
+  const octave = parseInt(m[3], 10);
+  const key = letter + acc;
+  const semi = NOTE_SEMITONES[key];
+  if (semi === undefined) return null;
+  return (octave + 1) * 12 + semi;
+}
+
+function midiToFreq(midi: number): number {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+/** GM Level 1 drum map (channel 10), MIDI notes 35–81. */
+const GM_DRUM_NAMES: Record<number, string> = {
+  35: 'Acoustic Bass Drum',
+  36: 'Bass Drum 1',
+  37: 'Side Stick',
+  38: 'Acoustic Snare',
+  39: 'Hand Clap',
+  40: 'Electric Snare',
+  41: 'Low Floor Tom',
+  42: 'Closed Hi-Hat',
+  43: 'High Floor Tom',
+  44: 'Pedal Hi-Hat',
+  45: 'Low Tom',
+  46: 'Open Hi-Hat',
+  47: 'Low-Mid Tom',
+  48: 'Hi-Mid Tom',
+  49: 'Crash Cymbal 1',
+  50: 'High Tom',
+  51: 'Ride Cymbal 1',
+  52: 'Chinese Cymbal',
+  53: 'Ride Bell',
+  54: 'Tambourine',
+  55: 'Splash Cymbal',
+  56: 'Cowbell',
+  57: 'Crash Cymbal 2',
+  58: 'Vibraslap',
+  59: 'Ride Cymbal 2',
+  60: 'Hi Bongo',
+  61: 'Low Bongo',
+  62: 'Mute Hi Conga',
+  63: 'Open Hi Conga',
+  64: 'Low Conga',
+  65: 'High Timbale',
+  66: 'Low Timbale',
+  67: 'High Agogo',
+  68: 'Low Agogo',
+  69: 'Cabasa',
+  70: 'Maracas',
+  71: 'Short Whistle',
+  72: 'Long Whistle',
+  73: 'Short Guiro',
+  74: 'Long Guiro',
+  75: 'Claves',
+  76: 'Hi Wood Block',
+  77: 'Low Wood Block',
+  78: 'Mute Cuica',
+  79: 'Open Cuica',
+  80: 'Mute Triangle',
+  81: 'Open Triangle',
+};
+
+export interface ParsedInstNote {
+  noteName: string;
+  instType?: string;
+  instLine: string;
+  range: monaco.IRange;
+}
+
+const NOTE_ASSIGNMENT_RE = /\bnote\s*=\s*([A-G][#bB]?-?\d+)/gi;
+
+export function parseInstTypeFromLine(line: string): string | undefined {
+  const match = /\btype\s*=\s*([a-zA-Z][\w-]*)/.exec(line);
+  return match?.[1]?.toLowerCase();
+}
+
+export function isPercussionInstrument(instType?: string, line?: string): boolean {
+  if (instType?.includes('noise') || instType === 'dmc') return true;
+  if (line && /\btone_mix\s*=\s*true\b/i.test(line)) return true;
+  return false;
+}
+
+/** hUGETracker note index (0 = MIDI 36); clamps/transposes like the UGE exporter. */
+export function noteToUgeIndex(midi: number): number | null {
+  let ugeIndex = midi - 36;
+  while (ugeIndex < 0 && ugeIndex + 12 <= 72) ugeIndex += 12;
+  if (ugeIndex < 0 || ugeIndex > 72) return null;
+  return ugeIndex;
+}
+
+export function getGmDrumName(midi: number): string | null {
+  return GM_DRUM_NAMES[midi] ?? null;
+}
+
+/** Parse `note=C7` when the cursor is on an instrument definition line. */
+export function parseNoteAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+): ParsedInstNote | null {
+  const line = model.getLineContent(position.lineNumber);
+  if (!/^\s*inst\s+/.test(line)) return null;
+
+  const col0 = position.column - 1;
+  const re = new RegExp(NOTE_ASSIGNMENT_RE.source, 'gi');
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(line)) !== null) {
+    const tokenStart = match.index;
+    const tokenEnd = match.index + match[0].length;
+    if (col0 < tokenStart || col0 >= tokenEnd) continue;
+
+    return {
+      noteName: match[1],
+      instType: parseInstTypeFromLine(line),
+      instLine: line,
+      range: {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: tokenStart + 1,
+        endColumn: tokenEnd + 1,
+      },
+    };
+  }
+
+  return null;
+}
+
+function formatFrequency(hz: number): string {
+  return hz >= 100 ? `${hz.toFixed(1)} Hz` : `${hz.toFixed(2)} Hz`;
+}
+
+export function buildNoteHoverMarkdown(
+  parsed: ParsedInstNote,
+  chip: string = 'gameboy',
+): string {
+  const { noteName, instType, instLine } = parsed;
+  const midi = noteToMidi(noteName);
+  const percussion = isPercussionInstrument(instType, instLine);
+  const canonicalChip = chip.toLowerCase();
+
+  const lines = [
+    '**Default hit note** — pitch used when this instrument name is written as a pattern token.',
+    '',
+    `Note **${noteName}**`,
+  ];
+
+  if (midi === null) {
+    lines.push('', 'Could not parse this note name — use scientific pitch notation (e.g. `C4`, `F#5`, `Bb3`).');
+    return lines.join('\n');
+  }
+
+  const freq = midiToFreq(midi);
+  lines.push(`MIDI **${midi}** · ${formatFrequency(freq)}`);
+
+  if (canonicalChip === 'gameboy' || canonicalChip === 'gb' || canonicalChip === 'dmg') {
+    const ugeIndex = noteToUgeIndex(midi);
+    if (ugeIndex !== null) {
+      lines.push(`hUGE export index: **${ugeIndex}**`);
+    }
+  }
+
+  const drumName = getGmDrumName(midi);
+  if (drumName) {
+    lines.push(`GM drum map (reference): **${drumName}**`);
+  }
+
+  lines.push('');
+
+  if (instType?.includes('noise')) {
+    lines.push(
+      'On **noise** instruments, `note=` sets the exported pitch column (hUGETracker) and helps tune the noise period.',
+      'Playback still uses the instrument definition (`env=`, `width=`, …); combine those with `note=` to sculpt kicks, snares, and hats.',
+      '',
+      'Example: `inst snare type=noise gb:width=7 env=13,down note=C7`',
+    );
+  } else if (instType === 'dmc') {
+    lines.push(
+      'DMC samples are not pitch-driven the same way as tone channels; `note=` is mainly used for MIDI/export metadata.',
+    );
+  } else if (percussion) {
+    lines.push(
+      'With **tone + noise mix** (`tone_mix=true`), `note=` sets the stick/click layer pitch on named hits.',
+      '',
+      'Example: `inst hat type=tone1 tone_mix=true tone_frames=1 note=E7`',
+    );
+  } else {
+    lines.push(
+      'On melodic channels, named hits play at this frequency instead of requiring an explicit note in the pattern.',
+      '',
+      'Example: `inst kick type=pulse1 duty=12.5 env=15,down note=C2` → `pat drums = kick . snare .`',
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/apps/web-ui/src/editor/inst-property-hover.ts
+++ b/apps/web-ui/src/editor/inst-property-hover.ts
@@ -1,0 +1,397 @@
+/**
+ * Hover helpers for instrument property assignments on `inst` lines
+ * (e.g. `duty=50`, `vol=10`, `type=pulse1`, `noise_rate=2`).
+ */
+
+import type * as monaco from 'monaco-editor';
+import { chipRegistry } from '@beatbax/engine/chips';
+import {
+  getChipInstrumentMeta,
+  getInstPropertyCompletions,
+  getInstPropertyNamesForChip,
+} from './instrument-meta';
+
+export interface ParsedInstProperty {
+  property: string;
+  value: string;
+  range: monaco.IRange;
+}
+
+const ASSIGNMENT_VALUE_RE =
+  /=\s*([A-Za-z][\w.-]*|\d+(?:\.\d+)?)/;
+
+function resolveChip(chip: string): string {
+  return chipRegistry.resolve(chip);
+}
+
+/** Property names that may show a keyword hover on `inst` lines. */
+function getKeywordHoverProperties(chip: string): Set<string> {
+  const canonical = resolveChip(chip);
+  const names = new Set(getInstPropertyNamesForChip(canonical));
+  const docs = chipRegistry.get(canonical)?.uiContributions?.hoverDocs ?? {};
+  for (const key of Object.keys(docs)) {
+    if (!key.includes(':')) names.add(key);
+  }
+  return names;
+}
+
+function getValueHoverProperties(chip: string): Set<string> {
+  const canonical = resolveChip(chip);
+  const names = getKeywordHoverProperties(chip);
+  // Values are only rendered for a focused subset; macros use dedicated hovers.
+  const valueProps = [
+    'type', 'vol', 'duty', 'noise_mode', 'noise_rate', 'tone', 'tone_mix',
+    'env_bass', 'env_shape', 'noise_frames', 'tone_frames', 'tone_vol', 'chipRegion',
+  ];
+  return new Set([...names].filter((key) => valueProps.includes(key)));
+}
+
+interface InstAssignmentMatch {
+  property: string;
+  propStart: number;
+  propEnd: number;
+  value: string;
+  valueStart: number;
+  tokenEnd: number;
+}
+
+function iterInstAssignments(
+  line: string,
+  allowedProperties: Set<string>,
+): InstAssignmentMatch[] {
+  const matches: InstAssignmentMatch[] = [];
+  const re = /\b([a-z][a-z0-9_]*)\s*=/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(line)) !== null) {
+    const property = match[1].toLowerCase();
+    if (!allowedProperties.has(property)) continue;
+
+    const propStart = match.index;
+    const propEnd = propStart + match[1].length;
+    const valueMatch = ASSIGNMENT_VALUE_RE.exec(line.slice(propEnd));
+    if (!valueMatch) continue;
+
+    const value = valueMatch[1];
+    const assignStart = propEnd + valueMatch.index!;
+    const valueStart = assignStart + valueMatch[0].indexOf(value);
+    const tokenEnd = assignStart + valueMatch[0].length;
+
+    matches.push({ property, propStart, propEnd, value, valueStart, tokenEnd });
+  }
+
+  return matches;
+}
+
+function parseAssignmentAtPosition(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+  allowedProperties: Set<string>,
+  onKeyword: boolean,
+): ParsedInstProperty | null {
+  const line = model.getLineContent(position.lineNumber);
+  if (!/^\s*inst\s+/.test(line)) return null;
+
+  const col0 = position.column - 1;
+
+  for (const entry of iterInstAssignments(line, allowedProperties)) {
+    const { property, propStart, propEnd, value, valueStart, tokenEnd } = entry;
+    if (col0 < propStart || col0 >= tokenEnd) continue;
+
+    const onPropName = col0 >= propStart && col0 < propEnd;
+    const onValue = col0 >= valueStart && col0 < tokenEnd;
+    if (onKeyword && !onPropName) continue;
+    if (!onKeyword && !onValue) continue;
+
+    return {
+      property,
+      value,
+      range: onKeyword
+        ? {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: propStart + 1,
+          endColumn: propEnd + 1,
+        }
+        : {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: propStart + 1,
+          endColumn: tokenEnd + 1,
+        },
+    };
+  }
+
+  return null;
+}
+
+const DUTY_LABELS: Record<string, string> = {
+  '12': 'Thin, bright, cutting',
+  '12.5': 'Thin, bright, cutting',
+  '25': 'Classic hollow square',
+  '50': 'Balanced, full-sounding',
+  '75': 'Dark, thick (inverted 25%)',
+};
+
+function buildDutyValueMarkdown(value: string): string {
+  const label = DUTY_LABELS[value] ?? DUTY_LABELS[String(parseFloat(value))];
+  const lines = [
+    `**Duty cycle ${value}%** — pulse channel pulse width.`,
+  ];
+  if (label) lines.push('', label);
+  lines.push(
+    '',
+    'Valid values: `12` · `12.5` · `25` · `50` · `75`',
+    '',
+    'Example: `inst lead type=pulse1 duty=25 env=13,down`',
+  );
+  return lines.join('\n');
+}
+
+function buildVolValueMarkdown(value: string, chip: string, instType?: string): string {
+  const level = Number.parseInt(value, 10);
+  const canonical = resolveChip(chip);
+
+  if (canonical === 'sms') {
+    const lines = [
+      `**Volume ${value}** — SN76489 attenuation **0–15** (**0 = loudest**, **15 = silent**).`,
+    ];
+    if (Number.isFinite(level)) {
+      if (level === 0) {
+        lines.push('', '**Maximum level** — no attenuation.');
+      } else if (level === 15) {
+        lines.push('', '**Mute** — full attenuation.');
+      } else {
+        const loudness = Math.round(((15 - level) / 15) * 100);
+        lines.push('', `Approximately **${loudness}%** of maximum SMS level.`);
+      }
+    }
+    lines.push(
+      '',
+      'Use `vol_env=[…]` for decay and dynamics; static `vol` is overridden by an active macro.',
+      '',
+      'Example: `inst lead type=tone1 vol=10`',
+    );
+    return lines.join('\n');
+  }
+
+  const lines = [
+    `**Volume ${value}** — constant amplitude **0–15**.`,
+  ];
+
+  if (Number.isFinite(level)) {
+    if (level === 0) {
+      lines.push('', '**Mute** — silences the channel.');
+    } else {
+      const pct = Math.round((level / 15) * 100);
+      lines.push('', `Approximately **${pct}%** of maximum channel level.`);
+    }
+  }
+
+  if (canonical === 'spectrum-128') {
+    lines.push(
+      '',
+      '**0 = silent** · **15 = loudest**. Use `vol_env` for hardware envelope (global, one at a time).',
+      'For independent drum decay, combine fixed `vol` with `volSlide` on pattern notes.',
+    );
+  } else if (instType === 'triangle') {
+    lines.push(
+      '',
+      '_Triangle hardware is always at full level; only `vol=0` has an audible effect._',
+    );
+  } else {
+    lines.push(
+      '',
+      'Bypasses hardware envelope decay — use instead of `env=` for a flat level.',
+      'Overridden when `vol_env=[…]` is present.',
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function buildNoiseModeValueMarkdown(value: string): string {
+  const mode = value.toLowerCase();
+  if (mode === 'white') {
+    return [
+      '**noise_mode=white** — full-bandwidth white noise.',
+      '',
+      'LFSR feedback from bits 0 and 1; long period (~32767 samples).',
+      'Best for kicks, snares, and broad percussion.',
+      '',
+      'Example: `inst kick type=noise noise_mode=white noise_rate=2 vol_env=[0,4,8,12,15]`',
+    ].join('\n');
+  }
+  if (mode === 'periodic') {
+    return [
+      '**noise_mode=periodic** — short-period metallic noise.',
+      '',
+      'LFSR feedback from bits 0 and 6; ~93-sample period, more tonal character.',
+      'Useful for special FX and metallic textures.',
+      '',
+      'Example: `inst fx type=noise noise_mode=periodic noise_rate=1 vol=10`',
+    ].join('\n');
+  }
+  return [
+    `**noise_mode=${value}** — use \`white\` or \`periodic\`.`,
+  ].join('\n');
+}
+
+function buildNoiseRateValueMarkdown(value: string, chip: string): string {
+  const canonical = resolveChip(chip);
+  if (canonical === 'spectrum-128') {
+    const labels: Record<string, string> = {
+      '0': 'Fastest / brightest noise (global R6)',
+      '4': 'Typical kick attack range',
+      '6': 'Typical snare body range',
+      '10': 'Shared rate for multiplexed drum kits',
+    };
+    const label = labels[value];
+    const lines = [
+      `**noise_rate=${value}** — AY R6 noise period (**0–31**, global).`,
+    ];
+    if (label) lines.push('', label);
+    lines.push(
+      '',
+      '⚠ Only one noise period is active per chip tick — use the same value for overlapping hits.',
+      '',
+      'Example: `inst kick type=tone3 tone_mix=true noise_rate=4 note=C3`',
+    );
+    return lines.join('\n');
+  }
+
+  const labels: Record<string, string> = {
+    '0': 'Highest frequency (clock ÷ 128) — hi-hats, bright noise',
+    '1': 'Medium frequency (clock ÷ 256) — snare range',
+    '2': 'Lowest frequency (clock ÷ 512) — kicks, boomy transients',
+    tone3: 'Follows Tone 3 period — synced kick/bass noise',
+  };
+  const label = labels[value] ?? labels[value.toLowerCase()];
+  const lines = [
+    `**noise_rate=${value}** — SN76489 noise clock divisor.`,
+  ];
+  if (label) lines.push('', label);
+  lines.push(
+    '',
+    'Valid values: `0` · `1` · `2` · `tone3`',
+    '',
+    'Example: `inst kick type=noise noise_mode=white noise_rate=2 vol=5`',
+  );
+  return lines.join('\n');
+}
+
+function buildTypeValueMarkdown(value: string, chip: string): string | null {
+  const canonical = resolveChip(chip);
+  const chipDoc = chipRegistry.get(canonical)?.uiContributions?.hoverDocs?.[value];
+  if (chipDoc) return chipDoc;
+
+  const meta = getChipInstrumentMeta(canonical);
+  if (!meta.types.includes(value)) return null;
+
+  const chipLabel = canonical === 'nes' ? 'NES'
+    : canonical === 'sms' ? 'SMS'
+      : canonical === 'gameboy' ? 'Game Boy'
+        : canonical === 'spectrum-128' ? 'Spectrum 128 / AY'
+          : canonical;
+
+  return [
+    `**${value}** — ${chipLabel} instrument channel type.`,
+    '',
+    `Valid types: ${meta.types.map((t) => `\`${t}\``).join(' · ')}`,
+  ].join('\n');
+}
+
+function buildPropertyKeywordMarkdown(property: string, chip: string): string | null {
+  const canonical = resolveChip(chip);
+  const chipDoc = chipRegistry.get(canonical)?.uiContributions?.hoverDocs?.[property];
+  if (chipDoc) return chipDoc;
+
+  const meta = getInstPropertyCompletions(canonical, property);
+  if (!meta) return null;
+
+  const lines = [`**${property}**`];
+  if (meta.detail) lines.push(meta.detail);
+  if (meta.values?.length) {
+    lines.push('', `Values: ${meta.values.map((v) => `\`${v}\``).join(' · ')}`);
+  }
+  return lines.join('\n');
+}
+
+function parseInstTypeFromLine(line: string): string | undefined {
+  const match = /\btype\s*=\s*([a-zA-Z][\w-]*)/.exec(line);
+  return match?.[1]?.toLowerCase();
+}
+
+/** Hover when the cursor is on a property **name** (`type`, `vol`, …) in an `inst` line. */
+export function buildInstPropertyKeywordHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+  chip: string,
+): monaco.languages.Hover | null {
+  const parsed = parseAssignmentAtPosition(
+    model,
+    position,
+    getKeywordHoverProperties(chip),
+    true,
+  );
+  if (!parsed) return null;
+
+  const markdown = buildPropertyKeywordMarkdown(parsed.property, chip);
+  if (!markdown) return null;
+
+  return {
+    range: parsed.range,
+    contents: [{ value: markdown }],
+  };
+}
+
+/** Hover when the cursor is on a property **value** (`tone1`, `10`, …) in an `inst` line. */
+export function buildInstPropertyHover(
+  model: monaco.editor.ITextModel,
+  position: monaco.IPosition,
+  chip: string,
+): monaco.languages.Hover | null {
+  const parsed = parseAssignmentAtPosition(
+    model,
+    position,
+    getValueHoverProperties(chip),
+    false,
+  );
+  if (!parsed) return null;
+
+  const line = model.getLineContent(position.lineNumber);
+  const instType = parseInstTypeFromLine(line);
+
+  let markdown: string | null = null;
+  switch (parsed.property) {
+    case 'duty':
+      markdown = buildDutyValueMarkdown(parsed.value);
+      break;
+    case 'vol':
+      markdown = buildVolValueMarkdown(parsed.value, chip, instType);
+      break;
+    case 'type':
+      markdown = buildTypeValueMarkdown(parsed.value, chip);
+      break;
+    case 'noise_mode':
+      markdown = buildNoiseModeValueMarkdown(parsed.value);
+      break;
+    case 'noise_rate':
+      markdown = buildNoiseRateValueMarkdown(parsed.value, chip);
+      break;
+    default: {
+      const chipDoc = chipRegistry.get(resolveChip(chip))?.uiContributions?.hoverDocs?.[parsed.property];
+      if (chipDoc && /^(true|false|\d+)$/i.test(parsed.value)) {
+        markdown = chipDoc;
+      }
+      break;
+    }
+  }
+
+  if (!markdown) return null;
+
+  return {
+    range: parsed.range,
+    contents: [{ value: markdown }],
+  };
+}

--- a/apps/web-ui/src/editor/inst-property-hover.ts
+++ b/apps/web-ui/src/editor/inst-property-hover.ts
@@ -55,20 +55,31 @@ interface InstAssignmentMatch {
   tokenEnd: number;
 }
 
+/** Resolve a source property token to its canonical allowed key (case-insensitive). */
+function resolveAllowedProperty(name: string, allowedProperties: Set<string>): string | null {
+  if (allowedProperties.has(name)) return name;
+  const lower = name.toLowerCase();
+  for (const key of allowedProperties) {
+    if (key.toLowerCase() === lower) return key;
+  }
+  return null;
+}
+
 function iterInstAssignments(
   line: string,
   allowedProperties: Set<string>,
 ): InstAssignmentMatch[] {
   const matches: InstAssignmentMatch[] = [];
-  const re = /\b([a-z][a-z0-9_]*)\s*=/gi;
+  const re = /\b([a-zA-Z][a-zA-Z0-9_]*)\s*=/g;
   let match: RegExpExecArray | null;
 
   while ((match = re.exec(line)) !== null) {
-    const property = match[1].toLowerCase();
-    if (!allowedProperties.has(property)) continue;
+    const rawProperty = match[1];
+    const property = resolveAllowedProperty(rawProperty, allowedProperties);
+    if (!property) continue;
 
     const propStart = match.index;
-    const propEnd = propStart + match[1].length;
+    const propEnd = propStart + rawProperty.length;
     const valueMatch = ASSIGNMENT_VALUE_RE.exec(line.slice(propEnd));
     if (!valueMatch) continue;
 
@@ -317,6 +328,23 @@ function buildPropertyKeywordMarkdown(property: string, chip: string): string | 
   return lines.join('\n');
 }
 
+/** Value hover backed by chip `hoverDocs[property]` (any literal, not only booleans/numbers). */
+function buildChipDocPropertyValueMarkdown(
+  property: string,
+  value: string,
+  chip: string,
+): string | null {
+  const canonical = resolveChip(chip);
+  const chipDoc = chipRegistry.get(canonical)?.uiContributions?.hoverDocs?.[property];
+  if (!chipDoc) return null;
+
+  const meta = getInstPropertyCompletions(canonical, property);
+  const lines = [`**${property}=${value}**`];
+  if (meta?.detail) lines.push('', meta.detail);
+  lines.push('', chipDoc);
+  return lines.join('\n');
+}
+
 function parseInstTypeFromLine(line: string): string | undefined {
   const match = /\btype\s*=\s*([a-zA-Z][\w-]*)/.exec(line);
   return match?.[1]?.toLowerCase();
@@ -380,9 +408,16 @@ export function buildInstPropertyHover(
       markdown = buildNoiseRateValueMarkdown(parsed.value, chip);
       break;
     default: {
-      const chipDoc = chipRegistry.get(resolveChip(chip))?.uiContributions?.hoverDocs?.[parsed.property];
-      if (chipDoc && /^(true|false|\d+)$/i.test(parsed.value)) {
-        markdown = chipDoc;
+      markdown = buildChipDocPropertyValueMarkdown(parsed.property, parsed.value, chip);
+      if (!markdown) {
+        const canonical = resolveChip(chip);
+        const meta = getInstPropertyCompletions(canonical, parsed.property);
+        if (meta?.values?.includes(parsed.value)) {
+          const lines = [`**${parsed.property}=${parsed.value}**`];
+          if (meta.detail) lines.push('', meta.detail);
+          lines.push('', `Values: ${meta.values.map((v) => `\`${v}\``).join(' · ')}`);
+          markdown = lines.join('\n');
+        }
       }
       break;
     }

--- a/apps/web-ui/src/editor/instrument-meta.ts
+++ b/apps/web-ui/src/editor/instrument-meta.ts
@@ -71,6 +71,22 @@ export const CHIP_INSTRUMENT_META: Record<string, ChipInstrumentMeta> = {
       gm: { detail: 'MIDI program 0–127' },
     },
   },
+  sms: {
+    types: ['tone1', 'tone2', 'tone3', 'noise'],
+    properties: {
+      type: { values: ['tone1', 'tone2', 'tone3', 'noise'], detail: 'SN76489 channel type' },
+      vol: { values: ['0', '5', '10', '15'], detail: 'Attenuation 0–15 (0=loudest, 15=mute)' },
+      vol_env: { detail: 'Volume macro [levels|loop]; 0=loudest, 15=silent' },
+      arp_env: { detail: 'Arpeggio macro semitone offsets' },
+      pitch_env: { detail: 'Pitch macro semitone offsets' },
+      noise_mode: { values: ['white', 'periodic'], detail: 'LFSR noise mode' },
+      noise_rate: { values: ['0', '1', '2', 'tone3'], detail: 'Noise clock divisor' },
+      noise_rate_env: { detail: 'Animate noise_rate per frame' },
+      gg_pan: { values: ['L', 'C', 'R'], detail: 'Game Gear stereo routing' },
+      note: { detail: 'Default note for hits' },
+      gm: { detail: 'MIDI program 0–127' },
+    },
+  },
 };
 
 /** Canonical chip ids for instrument metadata (mirrors chipRegistry aliases). */
@@ -81,6 +97,8 @@ const CHIP_ALIASES: Record<string, string> = {
   spectrum: 'spectrum-128',
   cpc: 'spectrum-128',
   'amstrad-cpc': 'spectrum-128',
+  gg: 'sms',
+  gamegear: 'sms',
 };
 
 const GENERIC_PROPERTIES: Record<string, InstPropertyMeta> = {

--- a/apps/web-ui/src/input/midi-step-entry-controller.ts
+++ b/apps/web-ui/src/input/midi-step-entry-controller.ts
@@ -18,8 +18,13 @@ import { createLogger } from '@beatbax/engine/util/logger';
 import {
   MidiStepEntryService,
   isCursorInsidePatBody,
+  isEffectDefinitionLine,
+  isInstrumentDefinitionLine,
+  isMidiPreviewLine,
+  resolveEffectNameFromLine,
   extractNoteTokenSpans,
   formatNoteToken,
+  prefixSpacingBeforeInsert,
   type StepLength,
   type EntryMode,
   type ScaleSnapMode,
@@ -30,6 +35,7 @@ import {
   midiNoteToName,
 } from './midi-step-entry';
 import { resolvePrimaryPatternLock } from '../editor/scale-context';
+import { ensureAudioCtxReady } from '../editor/codelens-preview';
 import {
   settingMidiInputEnabled,
   settingMidiInputDevice,
@@ -51,6 +57,8 @@ export interface MidiStepEntryControllerOptions {
   getEditor: () => monaco.editor.IStandaloneCodeEditor | null;
   /** Called with a note name to trigger a brief audition playback. */
   onAuditionNote?: (noteName: string) => void;
+  /** Called with an effect name to trigger effect preset preview. */
+  onPreviewEffect?: (effectName: string) => void;
   /** Called with a human-readable warning message. */
   onWarning?: (message: string) => void;
   /** Called when the armed state changes. Used to update the record button UI. */
@@ -89,6 +97,9 @@ export class MidiStepEntryController {
       onAuditionStop: (_noteName) => {
         // Audition stop is informational for now; the playback engine handles
         // timing, so we don't need to explicitly stop anything here.
+      },
+      onIdlePreview: (noteName) => {
+        this._handleIdlePreview(noteName);
       },
       onWarning: (message) => {
         this.opts.onWarning?.(message);
@@ -188,6 +199,7 @@ export class MidiStepEntryController {
     const armed = this.service.isArmed();
     this.opts.onArmedChanged?.(armed);
     if (armed) {
+      ensureAudioCtxReady();
       log.info('MIDI step entry armed');
     }
   }
@@ -286,6 +298,10 @@ export class MidiStepEntryController {
 
     // Gate: only allow entry inside a pat body
     if (!isCursorInsidePatBody(lineText, pos.column)) {
+      if (isMidiPreviewLine(lineText, pos.column)) {
+        this._triggerLinePreview(lineText, pos.column, noteName);
+        return;
+      }
       this.opts.onWarning?.('MIDI step entry: cursor must be inside a pat body (after the = on a pat line).');
       return;
     }
@@ -295,9 +311,40 @@ export class MidiStepEntryController {
     const token = formatNoteToken(noteForInsert, stepLength, emitDuration);
 
     if (entryMode === 'overwrite-selection') {
-      this._replaceSelectionOrInsert(editor, model, pos, token, autoAdvance);
+      if (this._replaceSelectionOrInsert(editor, model, pos, token, autoAdvance)) {
+        this._maybeAuditionAfterInsert(noteForInsert);
+      }
     } else {
       this._insertAtCursor(editor, model, pos, token, autoAdvance);
+      this._maybeAuditionAfterInsert(noteForInsert);
+    }
+  }
+
+  private _maybeAuditionAfterInsert(noteName: string): void {
+    if (!this.service.isAuditionNotes()) return;
+    this.opts.onAuditionNote?.(noteName);
+  }
+
+  private _handleIdlePreview(noteName: string): void {
+    if (!settingMidiInputEnabled.get()) return;
+    ensureAudioCtxReady();
+    const editor = this.opts.getEditor();
+    if (!editor) return;
+    const model = editor.getModel();
+    const pos = editor.getPosition();
+    if (!model || !pos) return;
+    const lineText = model.getLineContent(pos.lineNumber);
+    this._triggerLinePreview(lineText, pos.column, noteName);
+  }
+
+  private _triggerLinePreview(lineText: string, column: number, noteName: string): void {
+    if (isEffectDefinitionLine(lineText)) {
+      const effectName = resolveEffectNameFromLine(lineText);
+      if (effectName) this.opts.onPreviewEffect?.(effectName);
+      return;
+    }
+    if (isInstrumentDefinitionLine(lineText) || isCursorInsidePatBody(lineText, column)) {
+      this.opts.onAuditionNote?.(noteName);
     }
   }
 
@@ -322,7 +369,7 @@ export class MidiStepEntryController {
 
   private _insertAtCursor(
     editor: monaco.editor.IStandaloneCodeEditor,
-    _model: monaco.editor.ITextModel,
+    model: monaco.editor.ITextModel,
     pos: monaco.IPosition,
     token: string,
     autoAdvance: boolean,
@@ -334,6 +381,7 @@ export class MidiStepEntryController {
     const insertRange = new monaco.Range(pos.lineNumber, pos.column, pos.lineNumber, pos.column);
     let editRange: monaco.IRange = insertRange;
     let insertText: string;
+    const lineText = model.getLineContent(pos.lineNumber);
 
     if (!autoAdvance && this._noAdvanceStart) {
       // Replace-in-place: overwrite the token inserted by the previous note press.
@@ -348,14 +396,23 @@ export class MidiStepEntryController {
       }
     }
 
+    const isReplaceInPlace =
+      editRange.startLineNumber === editRange.endLineNumber &&
+      editRange.startColumn !== editRange.endColumn;
+
+    let noteToken = token;
+    if (!isReplaceInPlace) {
+      noteToken = prefixSpacingBeforeInsert(lineText, editRange.startColumn, token);
+    }
+
     if (autoAdvance) {
       // Append a space so the cursor lands after the token (ready for the next note).
-      insertText = `${token} `;
+      insertText = `${noteToken} `;
       this._noAdvanceStart = null;
     } else {
       // No trailing space — record where the token starts so a follow-up press
       // can replace it in-place.
-      insertText = token;
+      insertText = noteToken;
       this._noAdvanceStart = { lineNumber: pos.lineNumber, startColumn: editRange.startColumn };
     }
 
@@ -374,13 +431,13 @@ export class MidiStepEntryController {
     pos: monaco.IPosition,
     token: string,
     autoAdvance: boolean,
-  ): void {
+  ): boolean {
     const sel = editor.getSelection();
     if (!sel || (sel.startLineNumber === sel.endLineNumber && sel.startColumn === sel.endColumn)) {
       this._overwriteCycle = null;
       // No selection — fall back to insert at cursor
       this._insertAtCursor(editor, model, pos, token, autoAdvance);
-      return;
+      return true;
     }
 
     const continuingCycle = this._resolveOverwriteCycleSelection(editor, model, sel);
@@ -394,7 +451,7 @@ export class MidiStepEntryController {
       this._overwriteCycle = null;
       // Selection contains no note/rest tokens — warn and abort
       this.opts.onWarning?.('MIDI step entry: selection contains no note or rest tokens to replace.');
-      return;
+      return false;
     }
 
     const targetIndex = continuingCycle ? (continuingCycle.nextSpanIndex % spans.length) : 0;
@@ -436,6 +493,7 @@ export class MidiStepEntryController {
 
     this._noAdvanceStart = null;
     editor.focus();
+    return true;
   }
 
   private _resolveOverwriteCycleSelection(

--- a/apps/web-ui/src/input/midi-step-entry.ts
+++ b/apps/web-ui/src/input/midi-step-entry.ts
@@ -94,6 +94,8 @@ export interface MidiStepEntryCallbacks {
   onAuditionStart?: (noteName: string) => void;
   /** Called when a MIDI note-off occurs (for audition). Optional. */
   onAuditionStop?: (noteName: string) => void;
+  /** Called on note-on while step entry is disarmed (instrument/effect preview). Optional. */
+  onIdlePreview?: (noteName: string) => void;
   /** Called for non-fatal diagnostic messages. Optional. */
   onWarning?: (message: string) => void;
 }
@@ -164,6 +166,21 @@ export function formatNoteToken(
 }
 
 /**
+ * Prefix a leading space when inserting a note token immediately after a
+ * non-whitespace character (e.g. cursor after `A4` → insert ` C4`, not `C4`).
+ *
+ * @param lineText       Full pat line text
+ * @param insertColumn   1-based Monaco column where the token will be inserted
+ * @param token          Note token to insert
+ */
+export function prefixSpacingBeforeInsert(lineText: string, insertColumn: number, token: string): string {
+  if (insertColumn <= 1) return token;
+  const charBefore = lineText[insertColumn - 2];
+  if (charBefore === undefined || /\s/.test(charBefore)) return token;
+  return ` ${token}`;
+}
+
+/**
  * Check whether the given editor cursor position is inside the body of a
  * `pat` definition.
  *
@@ -180,6 +197,31 @@ export function isCursorInsidePatBody(lineText: string, column: number): boolean
   if (!patMatch) return false;
   // column is 1-based; patMatch[1].length is 0-based end of the "=" character
   return column > patMatch[1].length;
+}
+
+/** Extract the effect name from an `effect <name> =` definition line. */
+export function resolveEffectNameFromLine(lineText: string): string | null {
+  const match = lineText.match(/^\s*effect\s+([A-Za-z0-9_-]+)\s*=/);
+  return match?.[1] ?? null;
+}
+
+/** True when the line defines an instrument (`inst <name> ...`). */
+export function isInstrumentDefinitionLine(lineText: string): boolean {
+  return /^\s*inst\s+/.test(lineText);
+}
+
+/** True when the line defines an effect preset (`effect <name> = ...`). */
+export function isEffectDefinitionLine(lineText: string): boolean {
+  return /^\s*effect\s+/.test(lineText);
+}
+
+/**
+ * Whether a MIDI note-on should trigger preview (not step entry) for the
+ * current cursor line.
+ */
+export function isMidiPreviewLine(lineText: string, column: number): boolean {
+  if (isInstrumentDefinitionLine(lineText) || isEffectDefinitionLine(lineText)) return true;
+  return isCursorInsidePatBody(lineText, column);
 }
 
 /**
@@ -497,11 +539,16 @@ export class MidiStepEntryService {
       this._noteOnTimes.set(midiNote, Date.now());
     }
 
-    // Step entry only when armed
-    if (!this.armed) return;
+    // Preview instruments/effects when step entry is disarmed
+    if (!this.armed) {
+      this.callbacks.onIdlePreview?.(noteName);
+      return;
+    }
 
-    // Audition (play entered notes) only when armed
-    if (this.auditionNotes) {
+    // Step entry only when armed (below)
+    // Hold-duration mode: audition on note-on so the user hears pitch while holding.
+    // Instant step entry defers audition until after the note token is inserted (controller).
+    if (this.auditionNotes && this.useNoteDuration) {
       this.callbacks.onAuditionStart?.(noteName);
     }
 

--- a/apps/web-ui/src/main.ts
+++ b/apps/web-ui/src/main.ts
@@ -49,7 +49,7 @@ import {
   warningsToDiagnostics,
   type Diagnostic,
 } from './editor/diagnostics';
-import { setupCodeLensPreview, triggerStepEntryAudition } from './editor/codelens-preview';
+import { setupCodeLensPreview, triggerStepEntryAudition, triggerEffectPreview } from './editor/codelens-preview';
 import { setupGlyphMargin } from './editor/glyph-margin';
 import { setupCommandPalette } from './editor/command-palette';
 import { getInitialContent } from './app/bootstrap';
@@ -74,7 +74,7 @@ import {
   settingShowToolbar, settingShowTransportBar,
   settingShowPatternGrid, settingShowChannelMixer,
   settingShowSongVisualizer,
-  settingWordWrap, settingDefaultBpm, settingSongArtist,
+  settingWordWrap, settingFoldComments, settingDefaultBpm, settingSongArtist,
   settingDebugOverlay, settingDebugOverlayPosition, settingDebugOverlayOpacity,
   settingDebugOverlayFontSize, settingDebugExposePlayer,
   settingMidiInputEnabled,
@@ -1039,6 +1039,9 @@ const midiController = new MidiStepEntryController({
     const lineText = model.getLineContent(pos.lineNumber);
     triggerStepEntryAudition(lineText, noteName);
   },
+  onPreviewEffect: (effectName) => {
+    triggerEffectPreview(effectName);
+  },
   onWarning: (message) => {
     opWarn(outputPanel, message, 'midi');
   },
@@ -1502,6 +1505,7 @@ function createSongFromWizard(source: string, songName: string): void {
   storage.set(StorageKey.EDITOR_CONTENT, source);
   opLog(outputPanel, '📄 New song');
   emitParse(source);
+  scheduleCommentsFoldPreference();
 }
 
 function openSongFromDisk(): void {
@@ -1519,6 +1523,7 @@ function openSongFromDisk(): void {
       eventBus.emit('song:loaded', { filename: result.filename });
       menuBar.recordRecent(result.filename);
       emitParse(result.content);
+      scheduleCommentsFoldPreference();
       loadingOverlay.hide();
     },
     onError: () => loadingOverlay.hide(),
@@ -1529,6 +1534,43 @@ function openSongFromDisk(): void {
 // ─── LoadingOverlay ──────────────────────────────────────────────────────────
 // Used to block user interaction during async file loading operations.
 const loadingOverlay = new LoadingOverlay();
+
+function applyCommentsFoldPreference(folded = settingFoldComments.get()): void {
+  const monacoEditor = editor?.editor;
+  if (!monacoEditor) return;
+  if (folded) {
+    monacoEditor.trigger('toolbar', 'editor.foldAllBlockComments', null);
+  } else {
+    monacoEditor.trigger('toolbar', 'editor.unfoldAll', null);
+  }
+  toolbar?.setFoldCommentsActive(folded);
+}
+
+function scheduleCommentsFoldPreference(): void {
+  const folded = settingFoldComments.get();
+  if (!folded) {
+    applyCommentsFoldPreference(false);
+    return;
+  }
+
+  // Folding ranges are recomputed asynchronously after setValue; defer and retry.
+  const fold = () => applyCommentsFoldPreference(true);
+  requestAnimationFrame(() => requestAnimationFrame(fold));
+  window.setTimeout(fold, 100);
+}
+
+function toggleWordWrap(): void {
+  const wrap = !settingWordWrap.get();
+  settingWordWrap.set(wrap);
+  editor.editor?.updateOptions({ wordWrap: wrap ? 'on' : 'off' });
+  toolbar?.setWrapActive(wrap);
+}
+
+function toggleFoldAllComments(): void {
+  const folded = !settingFoldComments.get();
+  settingFoldComments.set(folded);
+  applyCommentsFoldPreference(folded);
+}
 
 const menuBar = new MenuBar({
   container: menuBarContainer,
@@ -1572,6 +1614,7 @@ const menuBar = new MenuBar({
     eventBus.emit('song:loaded', { filename });
     menuBar.recordRecent(filename);
     emitParse(content);
+    scheduleCommentsFoldPreference();
     loadingOverlay.hide();
   },
   onUndo: () => editor.editor?.trigger('menu', 'undo', null),
@@ -1579,6 +1622,7 @@ const menuBar = new MenuBar({
   onCut: () => editor.editor?.trigger('menu', 'editor.action.clipboardCutAction', null),
   onCopy: () => editor.editor?.trigger('menu', 'editor.action.clipboardCopyAction', null),
   onPaste: () => editor.editor?.trigger('menu', 'editor.action.clipboardPasteAction', null),
+  onSelectAll: () => editor.editor?.trigger('menu', 'editor.action.selectAll', null),
   onFind: () => editor.editor?.trigger('menu', 'actions.find', null),
   onReplace: () => editor.editor?.trigger('menu', 'editor.action.startFindReplaceAction', null),
   onZoomIn: () => {
@@ -1591,6 +1635,8 @@ const menuBar = new MenuBar({
   },
   onZoomReset: () => editor.editor?.updateOptions({ fontSize: 14 }),
   onToggleTheme: () => themeManager.toggle(),
+  onToggleWrapText: () => toggleWordWrap(),
+  onToggleFoldAll: () => toggleFoldAllComments(),
   onToggleAI: () => toggleAIAssistant(),
 });
 
@@ -1616,6 +1662,11 @@ if (claimNewSongWizardOnboarding(
 
 (window as any).__beatbax_menuBar = menuBar;
 
+menuBar.setWrapTextChecked(settingWordWrap.get());
+menuBar.setFoldAllChecked(settingFoldComments.get());
+settingWordWrap.subscribe((wrap) => menuBar.setWrapTextChecked(wrap));
+settingFoldComments.subscribe((folded) => menuBar.setFoldAllChecked(folded));
+
 // Keep the menu bar song name in sync with the parsed metadata.name directive.
 // Falls back to the loaded filename stem when no name directive is present.
 // 'song' is the internal sentinel for "no file loaded" — display as 'untitled'.
@@ -1638,12 +1689,17 @@ eventBus.on('preview:error', ({ message }: { message: string }) => {
 });
 
 // Seed MenuBar with persisted panel visibility so its toggle logic starts correct.
+// Feature-gated panels are only marked visible when their feature flag is enabled.
 menuBar.seedPanelVisible({
   toolbar:             readPanelVis(StorageKey.PANEL_VIS_TOOLBAR),
   'transport-bar':     readPanelVis(StorageKey.PANEL_VIS_TRANSPORT_BAR),
-  'channel-mixer':     readPanelVis(StorageKey.PANEL_VIS_CHANNEL_MIXER),
-  'pattern-grid':      readPanelVis(StorageKey.PANEL_VIS_PATTERN_GRID, false),
-  'song-visualizer':   readPanelVis(StorageKey.PANEL_VIS_SONG_VISUALIZER, false),
+  'channel-mixer':     isFeatureEnabled(FeatureFlag.CHANNEL_MIXER)
+    && readPanelVis(StorageKey.PANEL_VIS_CHANNEL_MIXER),
+  'pattern-grid':      isFeatureEnabled(FeatureFlag.PATTERN_GRID)
+    && readPanelVis(StorageKey.PANEL_VIS_PATTERN_GRID, false),
+  'song-visualizer':   isFeatureEnabled(FeatureFlag.SONG_VISUALIZER)
+    && readPanelVis(StorageKey.PANEL_VIS_SONG_VISUALIZER, false),
+  'ai-assistant':      isFeatureEnabled(FeatureFlag.AI_ASSISTANT),
 });
 // Apply initial pattern-grid visibility
 if (!readPanelVis(StorageKey.PANEL_VIS_PATTERN_GRID, false)) {
@@ -1651,7 +1707,7 @@ if (!readPanelVis(StorageKey.PANEL_VIS_PATTERN_GRID, false)) {
 }
 
 // ─── Toolbar ─────────────────────────────────────────────────────────────────
-let commentsFolded = false;
+
 toolbar = new Toolbar({
   container: toolbarContainer,
   eventBus,
@@ -1661,8 +1717,6 @@ toolbar = new Toolbar({
   onBeforeExampleLoad: () => playbackManager.stop(),
   onLoad: (filename, content) => {
     playbackManager.stop();
-    commentsFolded = false;
-    toolbar?.setFoldCommentsActive(false);
     setLoadedFilename(fileBaseStem(filename));
     editor.setValue?.(content);
     storage.set(StorageKey.EDITOR_CONTENT, content);
@@ -1670,6 +1724,7 @@ toolbar = new Toolbar({
     eventBus.emit('song:loaded', { filename });
     menuBar.recordRecent(filename);
     emitParse(content);
+    scheduleCommentsFoldPreference();
   },
   onExport: handleExport,
   onVerify: doVerify,
@@ -1677,31 +1732,20 @@ toolbar = new Toolbar({
   onSave:      () => menuBar.triggerSave(),
   onUndo:      () => editor.editor?.trigger('toolbar', 'undo', null),
   onRedo:      () => editor.editor?.trigger('toolbar', 'redo', null),
-  onSelectAll: () => editor.editor?.trigger('toolbar', 'editor.action.selectAll', null),
   onToggleTheme: () => themeManager.toggle(),
   onToggleWrap:  (wrap: boolean) => {
     settingWordWrap.set(wrap);
     editor.editor?.updateOptions({ wordWrap: wrap ? 'on' : 'off' });
   },
-  onToggleFoldComments: () => {
-    const monacoEditor = editor.editor;
-    if (!commentsFolded) {
-      // Monaco has a built-in command to fold all comment ranges at once.
-      monacoEditor.trigger('toolbar', 'editor.foldAllBlockComments', null);
-      commentsFolded = true;
-    } else {
-      monacoEditor.trigger('toolbar', 'editor.unfoldAll', null);
-      commentsFolded = false;
-    }
-    toolbar?.setFoldCommentsActive(commentsFolded);
-  },
+  onToggleFoldComments: () => toggleFoldAllComments(),
 });
 
 // Restore toolbar visibility
 if (!readPanelVis(StorageKey.PANEL_VIS_TOOLBAR)) toolbar.hide();
 // Sync the Wrap button active state with the persisted word-wrap setting
 toolbar.setWrapActive(settingWordWrap.get());
-toolbar.setFoldCommentsActive(false);
+toolbar.setFoldCommentsActive(settingFoldComments.get());
+if (settingFoldComments.get()) scheduleCommentsFoldPreference();
 // Sync theme icon with the current theme, then keep it updated
 toolbar.setThemeIcon(themeManager.currentTheme);
 toolbar.setChip(parsedChip.get());
@@ -1756,6 +1800,7 @@ const dragDrop = new DragDropHandler(document.body, {
     eventBus.emit('song:loaded', { filename });
     menuBar.recordRecent(filename);
     emitParse(content);
+    scheduleCommentsFoldPreference();
     setTimeout(() => playbackManager.play(getSource()), 200);
   },
 });
@@ -1778,6 +1823,7 @@ const dragDrop = new DragDropHandler(document.body, {
       eventBus.emit('song:loaded', { filename });
       menuBar.recordRecent(filename);
       emitParse(result.content);
+      scheduleCommentsFoldPreference();
       setTimeout(() => playbackManager.play(getSource()), 300);
     }
   } catch (err: any) {

--- a/apps/web-ui/src/panels/settings-sections/editor.ts
+++ b/apps/web-ui/src/panels/settings-sections/editor.ts
@@ -3,7 +3,7 @@
  */
 
 import {
-  settingAutoSave, settingWordWrap, settingCodeLens,
+  settingAutoSave, settingWordWrap, settingFoldComments, settingCodeLens,
   settingBeatDecorations, settingDefaultBpm, settingSongArtist, settingFontSize,
   settingMidiInputEnabled, settingMidiInputDevice, settingMidiStepLength,
   settingMidiEmitDurations, settingMidiEntryMode, settingMidiAutoAdvance,
@@ -210,6 +210,7 @@ export function buildEditorSection(): HTMLElement {
 export function resetEditorDefaults(): void {
   settingAutoSave.set(true);
   settingWordWrap.set(false);
+  settingFoldComments.set(false);
   settingCodeLens.set(true);
   settingBeatDecorations.set(true);
   settingDefaultBpm.set(128);

--- a/apps/web-ui/src/stores/settings.store.ts
+++ b/apps/web-ui/src/stores/settings.store.ts
@@ -72,6 +72,7 @@ export const settingVizBgImage         = stringAtom<string>(StorageKey.VIZ_BG_IM
 
 export const settingAutoSave        = boolAtom(StorageKey.AUTO_SAVE,         true);
 export const settingWordWrap        = boolAtom(StorageKey.WORD_WRAP,         false);
+export const settingFoldComments    = boolAtom(StorageKey.FOLD_COMMENTS,     false);
 export const settingCodeLens        = boolAtom(StorageKey.CODELENS,          true);
 export const settingBeatDecorations = boolAtom(StorageKey.BEAT_DECORATIONS,  true);
 export const settingDefaultBpm      = numberAtom(StorageKey.BPM,              128);
@@ -156,6 +157,7 @@ export const SECTION_KEYS: Record<string, string[]> = {
   editor: [
     StorageKey.AUTO_SAVE,
     StorageKey.WORD_WRAP,
+    StorageKey.FOLD_COMMENTS,
     StorageKey.CODELENS,
     StorageKey.BEAT_DECORATIONS,
     StorageKey.BPM,

--- a/apps/web-ui/src/styles.css
+++ b/apps/web-ui/src/styles.css
@@ -2577,14 +2577,14 @@
 }
 .bb-menu__item {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 5px 16px 5px 24px; color: #cccccc; cursor: pointer;
-  gap: 24px; outline: none; transition: background 0.1s;
+  padding: 5px 16px 5px 8px; color: #cccccc; cursor: pointer;
+  gap: 8px; outline: none; transition: background 0.1s;
 }
 .bb-menu__item:hover:not(.bb-menu__item--disabled),
 .bb-menu__item:focus:not(.bb-menu__item--disabled) { background: var(--bb-accent-bg); color: #ffffff; }
 .bb-menu__item--disabled { color: #666; cursor: default; }
 .bb-menu__item--submenu { position: relative; }
-.bb-menu__item-icon { width: 16px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
+.bb-menu__item-gutter { width: 16px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
 .bb-menu__item-label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .bb-menu__item-shortcut { font-size: 11px; color: #888; white-space: nowrap; flex-shrink: 0; }
 .bb-menu__item:hover .bb-menu__item-shortcut,
@@ -4183,14 +4183,14 @@
 }
 .bb-menu__item {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 5px 16px 5px 24px; color: #cccccc; cursor: pointer;
-  gap: 24px; outline: none; transition: background 0.1s;
+  padding: 5px 16px 5px 8px; color: #cccccc; cursor: pointer;
+  gap: 8px; outline: none; transition: background 0.1s;
 }
 .bb-menu__item:hover:not(.bb-menu__item--disabled),
 .bb-menu__item:focus:not(.bb-menu__item--disabled) { background: var(--bb-accent-bg); color: #ffffff; }
 .bb-menu__item--disabled { color: #666; cursor: default; }
 .bb-menu__item--submenu { position: relative; }
-.bb-menu__item-icon { width: 16px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
+.bb-menu__item-gutter { width: 16px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; }
 .bb-menu__item-label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .bb-menu__item-shortcut { font-size: 11px; color: #888; white-space: nowrap; flex-shrink: 0; }
 .bb-menu__item:hover .bb-menu__item-shortcut,

--- a/apps/web-ui/src/ui/menu-bar.ts
+++ b/apps/web-ui/src/ui/menu-bar.ts
@@ -18,15 +18,6 @@ import { exporterRegistry } from '../plugins/browser-exporter-registry';
 import { resolveUiChipId } from '../utils/chip-resolve';
 import type { LoadingOverlay } from './loading-overlay';
 
-/** Fallback icon per built-in exporter id (matches toolbar defaults). */
-const EXPORTER_DEFAULT_ICONS: Record<string, string> = {
-  json: 'document',
-  midi: 'musical-note',
-  wav:  'speaker-wave',
-  uge:  'cpu-chip',
-  vgm:  'cpu-chip',
-};
-
 const log = createLogger('ui:menu-bar');
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
@@ -77,6 +68,8 @@ export interface MenuBarOptions {
   onCopy?: () => void;
   /** Paste from clipboard. */
   onPaste?: () => void;
+  /** Select all text in the editor (Ctrl+A). */
+  onSelectAll?: () => void;
   /** Open Monaco find widget (Ctrl+F). */
   onFind?: () => void;
   /** Open Monaco find-and-replace widget (Ctrl+H). */
@@ -91,6 +84,10 @@ export interface MenuBarOptions {
   onZoomReset?: () => void;
   /** Toggle dark / light theme. */
   onToggleTheme?: () => void;
+  /** Toggle editor word wrap. */
+  onToggleWrapText?: () => void;
+  /** Fold or unfold all block comments. */
+  onToggleFoldAll?: () => void;
   /** Toggle the AI Copilot chat panel. */
   onToggleAI?: () => void;
   /** Open the Settings panel (Ctrl+,). */
@@ -149,6 +146,30 @@ function esc(str: string): string {
 
 // ─── MenuBar class ────────────────────────────────────────────────────────────
 
+/** Maps panel ids to menu item ids for toggle checkmarks. */
+const PANEL_CHECK_IDS: Record<string, string> = {
+  output: 'output-toggle',
+  problems: 'problems-toggle',
+  toolbar: 'toolbar-toggle',
+  'transport-bar': 'transport-bar-toggle',
+  'channel-mixer': 'channel-mixer-toggle',
+  'song-visualizer': 'song-visualizer-toggle',
+  'pattern-grid': 'pattern-grid-toggle',
+  help: 'help-panel-toggle',
+};
+
+/** Feature-gated panels — no checkmark unless the feature flag is on. */
+const PANEL_FEATURE_FLAGS: Partial<Record<string, string>> = {
+  'channel-mixer': FeatureFlag.CHANNEL_MIXER,
+  'pattern-grid': FeatureFlag.PATTERN_GRID,
+  'song-visualizer': FeatureFlag.SONG_VISUALIZER,
+};
+
+function isPanelFeatureEnabled(panel: string): boolean {
+  const flag = PANEL_FEATURE_FLAGS[panel];
+  return !flag || isFeatureEnabled(flag);
+}
+
 export class MenuBar {
   private el!: HTMLElement;
   private songNameEl!: HTMLElement;
@@ -169,6 +190,8 @@ export class MenuBar {
     ['channel-mixer', true],
     ['toolbar', true],
     ['transport-bar', true],
+    ['pattern-grid', false],
+    ['song-visualizer', false],
     ['ai-assistant', false],
   ]);
 
@@ -202,6 +225,24 @@ export class MenuBar {
     for (const [panel, visible] of Object.entries(states)) {
       this.panelVisible.set(panel, visible);
     }
+    this.refreshPanelToggleChecks();
+  }
+
+  /** Refresh checkmarks for panel visibility toggles. */
+  refreshPanelToggleChecks(): void {
+    for (const [panel, menuId] of Object.entries(PANEL_CHECK_IDS)) {
+      this.setItemChecked(menuId, this.isPanelEffectivelyVisible(panel));
+    }
+    this.setItemChecked(
+      'ai-assistant',
+      isFeatureEnabled(FeatureFlag.AI_ASSISTANT) && (this.panelVisible.get('ai-assistant') ?? false),
+    );
+  }
+
+  /** True when a panel is both feature-eligible and marked visible. */
+  private isPanelEffectivelyVisible(panel: string): boolean {
+    if (!isPanelFeatureEnabled(panel)) return false;
+    return this.panelVisible.get(panel) ?? false;
   }
 
   /** Enable or disable a menu item at runtime by its id. */
@@ -211,6 +252,25 @@ export class MenuBar {
     li.classList.toggle('bb-menu__item--disabled', !enabled);
     li.setAttribute('aria-disabled', String(!enabled));
     if (enabled) { li.tabIndex = -1; } else { li.removeAttribute('tabindex'); }
+  }
+
+  /** Update the checkmark for a checkable menu item. */
+  setItemChecked(id: string, checked: boolean): void {
+    const li = this.el.querySelector<HTMLElement>(`[data-item-id="${id}"]`);
+    if (!li) return;
+    const gutter = li.querySelector<HTMLElement>('.bb-menu__item-gutter');
+    if (gutter) gutter.textContent = checked ? '✓' : '';
+    if (li.getAttribute('role') === 'menuitemcheckbox') {
+      li.setAttribute('aria-checked', String(checked));
+    }
+  }
+
+  setWrapTextChecked(checked: boolean): void {
+    this.setItemChecked('wrap-text', checked);
+  }
+
+  setFoldAllChecked(checked: boolean): void {
+    this.setItemChecked('fold-all', checked);
   }
 
   triggerNew(): void { this.opts.onNew?.(); }
@@ -301,7 +361,7 @@ export class MenuBar {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         this.openMenuPanel(id, btn, panel);
-        (panel.querySelector<HTMLElement>('[role="menuitem"]:not([disabled])') ?? btn).focus();
+        (this.firstFocusableMenuItem(panel) ?? btn).focus();
       }
     });
 
@@ -323,13 +383,15 @@ export class MenuBar {
     }
 
     const li = document.createElement('li');
-    li.setAttribute('role', 'menuitem');
+    const checkable = !!def.checkable;
+    li.setAttribute('role', checkable ? 'menuitemcheckbox' : 'menuitem');
     li.className = 'bb-menu__item' + (def.disabled ? ' bb-menu__item--disabled' : '');
     if (def.disabled) li.setAttribute('aria-disabled', 'true');
     if (def.id) li.dataset.itemId = def.id;
+    if (checkable) li.setAttribute('aria-checked', 'false');
 
     li.innerHTML = `
-      ${def.icon ? `<span class="bb-menu__item-icon" aria-hidden="true">${icon(def.icon, 'w-3.5 h-3.5 inline-block align-text-bottom')}</span>` : ''}
+      <span class="bb-menu__item-gutter" aria-hidden="true"></span>
       <span class="bb-menu__item-label">${esc(def.label)}</span>
       ${def.shortcut ? `<span class="bb-menu__item-shortcut" aria-hidden="true">${esc(def.shortcut)}</span>` : ''}
     `;
@@ -364,7 +426,7 @@ export class MenuBar {
     if (def.id) li.dataset.itemId = def.id;
 
     li.innerHTML = `
-      <span class="bb-menu__item-icon" aria-hidden="true">${def.icon ? icon(def.icon, 'w-3.5 h-3.5 inline-block align-text-bottom') : ''}</span>
+      <span class="bb-menu__item-gutter" aria-hidden="true"></span>
       <span class="bb-menu__item-label">${esc(def.label)}</span>
       <span class="bb-menu__item-arrow" aria-hidden="true">${icon('chevron-down', 'w-3 h-3 inline-block -rotate-90')}</span>
     `;
@@ -408,7 +470,6 @@ export class MenuBar {
       {
         type: 'item',
         label: 'New',
-        icon: 'document-plus',
         // Ctrl+N is reserved by browsers (opens a new window) and cannot be
         // intercepted — access New via the menu or toolbar instead.
         action: () => this.opts.onNew?.(),
@@ -416,7 +477,6 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Open…',
-        icon: 'folder-open',
         shortcut: 'Ctrl+O',
         action: () => this.opts.onOpen?.(),
       },
@@ -424,21 +484,18 @@ export class MenuBar {
       {
         type: 'submenu',
         label: 'Export',
-        icon: 'arrow-up-tray',
         id: 'export',
         lazyChildren: () => this.exportItems(),
       },
       {
         type: 'item',
         label: 'Save',
-        icon: 'arrow-down-tray',
         shortcut: 'Ctrl+S',
         action: () => this.opts.onSave?.(),
       },
       {
         type: 'item',
         label: 'Save As…',
-        icon: 'document-arrow-down',
         shortcut: 'Ctrl+Shift+S',
         action: () => this.opts.onSaveAs?.(),
       },
@@ -446,7 +503,6 @@ export class MenuBar {
       {
         type: 'submenu',
         label: 'Recent Files',
-        icon: 'clock',
         id: 'recent-files',
         lazyChildren: () => this.recentFileItems(),
       },
@@ -458,14 +514,12 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Undo',
-        icon: 'arrow-uturn-left',
         shortcut: 'Ctrl+Z',
         action: () => this.opts.onUndo?.(),
       },
       {
         type: 'item',
         label: 'Redo',
-        icon: 'arrow-uturn-right',
         shortcut: 'Ctrl+Y',
         action: () => this.opts.onRedo?.(),
       },
@@ -473,21 +527,18 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Cut',
-        icon: 'scissors',
         shortcut: 'Ctrl+X',
         action: () => this.opts.onCut?.(),
       },
       {
         type: 'item',
         label: 'Copy',
-        icon: 'document-duplicate',
         shortcut: 'Ctrl+C',
         action: () => this.opts.onCopy?.(),
       },
       {
         type: 'item',
         label: 'Paste',
-        icon: 'clipboard-document',
         shortcut: 'Ctrl+V',
         action: () => this.opts.onPaste?.(),
       },
@@ -495,16 +546,21 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Find',
-        icon: 'magnifying-glass',
         shortcut: 'Ctrl+F',
         action: () => this.opts.onFind?.(),
       },
       {
         type: 'item',
         label: 'Replace',
-        icon: 'arrows-right-left',
         shortcut: 'Ctrl+H',
         action: () => this.opts.onReplace?.(),
+      },
+      { type: 'separator' },
+      {
+        type: 'item',
+        label: 'Select All',
+        shortcut: 'Ctrl+A',
+        action: () => this.opts.onSelectAll?.(),
       },
     ];
   }
@@ -513,12 +569,16 @@ export class MenuBar {
   private emitPanelToggle(panel: string): void {
     const next = !(this.panelVisible.get(panel) ?? false);
     this.panelVisible.set(panel, next);
+    const menuId = PANEL_CHECK_IDS[panel];
+    if (menuId) this.setItemChecked(menuId, this.isPanelEffectivelyVisible(panel));
     this.opts.eventBus.emit('panel:toggled', { panel, visible: next });
   }
 
   /** Show a tab panel (always emits visible:true). */
   private emitPanelShow(panel: string): void {
     this.panelVisible.set(panel, true);
+    const menuId = PANEL_CHECK_IDS[panel];
+    if (menuId) this.setItemChecked(menuId, this.isPanelEffectivelyVisible(panel));
     this.opts.eventBus.emit('panel:toggled', { panel, visible: true });
   }
 
@@ -527,7 +587,6 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Command Palette…',
-        icon: 'command-line',
         shortcut: 'Ctrl+Alt+P',
         action: () => this.opts.onOpenCommandPalette?.(),
       },
@@ -535,100 +594,108 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Output',
-        icon: 'command-line',
+        id: 'output-toggle',
+        checkable: true,
         shortcut: 'Ctrl+`',
-        action: () => this.emitPanelShow('output'),
+        action: () => this.emitPanelToggle('output'),
       },
       {
         type: 'item',
         label: 'Problems',
-        icon: 'exclamation-triangle',
+        id: 'problems-toggle',
+        checkable: true,
         shortcut: 'Alt+Shift+P',
-        action: () => this.emitPanelShow('problems'),
+        action: () => this.emitPanelToggle('problems'),
       },
       {
         type: 'item',
         label: 'Toolbar',
-        icon: 'bars-3',
+        id: 'toolbar-toggle',
+        checkable: true,
         shortcut: 'Ctrl+Shift+B',
         action: () => this.emitPanelToggle('toolbar'),
       },
       {
         type: 'item',
         label: 'Transport Bar',
-        icon: 'queue-list',
+        id: 'transport-bar-toggle',
+        checkable: true,
         shortcut: 'Ctrl+Shift+R',
         action: () => this.emitPanelToggle('transport-bar'),
       },
       {
         type: 'item',
         label: 'Channel Mixer',
-        icon: 'adjustments-vertical',
-        shortcut: 'Ctrl+Shift+M',
         id: 'channel-mixer-toggle',
+        checkable: true,
+        shortcut: 'Ctrl+Shift+M',
         disabled: !isFeatureEnabled(FeatureFlag.CHANNEL_MIXER),
         action: () => this.emitPanelToggle('channel-mixer'),
       },
       {
         type: 'item',
         label: 'Song Visualizer',
-        icon: 'adjustments-horizontal',
-        shortcut: 'Ctrl+Shift+V',
         id: 'song-visualizer-toggle',
+        checkable: true,
+        shortcut: 'Ctrl+Shift+V',
         disabled: !isFeatureEnabled(FeatureFlag.SONG_VISUALIZER),
         action: () => this.emitPanelToggle('song-visualizer'),
       },
       {
         type: 'item',
         label: 'Pattern Grid',
-        icon: 'bars-3-center-left',
-        shortcut: 'Ctrl+Shift+G',
         id: 'pattern-grid-toggle',
+        checkable: true,
+        shortcut: 'Ctrl+Shift+G',
         disabled: !isFeatureEnabled(FeatureFlag.PATTERN_GRID),
         action: () => this.emitPanelToggle('pattern-grid'),
       },
-/*      {
-        type: 'item',
-        label: 'Help',
-        shortcut: 'Shift+F1',
-        action: () => this.emitPanelShow('help'),
-      },
-      {
-        type: 'item',
-        label: 'Shortcuts',
-        shortcut: 'Alt+Shift+K',
-        action: () => this.emitPanelShow('shortcuts'),
-      },
-      */
       { type: 'separator' },
       {
         type: 'item',
         label: 'AI Assistant',
-        icon: 'sparkles',
-        shortcut: 'Alt+Shift+I',
         id: 'ai-assistant',
+        checkable: true,
+        shortcut: 'Alt+Shift+I',
         disabled: !isFeatureEnabled(FeatureFlag.AI_ASSISTANT),
-        action: () => this.opts.onToggleAI?.(),
+        action: () => {
+          this.opts.onToggleAI?.();
+          const enabled = isFeatureEnabled(FeatureFlag.AI_ASSISTANT);
+          this.panelVisible.set('ai-assistant', enabled);
+          this.setItemChecked('ai-assistant', enabled);
+        },
+      },
+      { type: 'separator' },
+      {
+        type: 'item',
+        label: 'Wrap Text',
+        id: 'wrap-text',
+        checkable: true,
+        action: () => this.opts.onToggleWrapText?.(),
+      },
+      {
+        type: 'item',
+        label: 'Fold All',
+        id: 'fold-all',
+        checkable: true,
+        action: () => this.opts.onToggleFoldAll?.(),
       },
       { type: 'separator' },
       {
         type: 'item',
         label: 'Zoom In',
-        icon: 'magnifying-glass-plus',
         shortcut: 'Ctrl++',
         action: () => this.opts.onZoomIn?.(),
       },
       {
         type: 'item',
         label: 'Zoom Out',
-        icon: 'magnifying-glass-minus',
         shortcut: 'Ctrl+-',
         action: () => this.opts.onZoomOut?.(),
       },
       {
         type: 'item',
         label: 'Reset Zoom',
-        icon: 'arrows-pointing-in',
         shortcut: 'Ctrl+0',
         action: () => this.opts.onZoomReset?.(),
       },
@@ -636,7 +703,6 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Theme (Dark / Light)',
-        icon: 'sun',
         shortcut: 'Ctrl+Shift+L',
         action: () => this.opts.onToggleTheme?.(),
       },
@@ -644,7 +710,6 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Settings…',
-        icon: 'cog-6-tooth',
         shortcut: `${isMac ? 'Cmd' : 'Ctrl'}+,`,
         action: () => this.opts.onShowSettings?.(),
       },
@@ -656,21 +721,19 @@ export class MenuBar {
       {
         type: 'item',
         label: 'Documentation',
-        icon: 'information-circle',
         action: () => window.open(DOCS_URL, '_blank', 'noopener,noreferrer'),
       },
       {
         type: 'item',
         label: 'Keyboard Shortcuts…',
-        icon: 'key',
         shortcut: 'Alt+Shift+K',
         action: () => this.opts.onShowShortcuts?.(),
       },
       {
-        // Opens the full Help Panel (syntax reference, snippets, keyboard shortcuts).
-        label: 'Help Panel…',
-        icon: 'question-mark-circle',
         type: 'item',
+        label: 'Help Panel…',
+        id: 'help-panel-toggle',
+        checkable: true,
         shortcut: 'Shift+F1',
         action: () => this.emitPanelToggle('help'),
       },
@@ -678,7 +741,6 @@ export class MenuBar {
       {
         type: 'submenu',
         label: 'Examples',
-        icon: 'book-open',
         id: 'examples',
         lazyChildren: () => this.exampleItems(),
       },
@@ -686,7 +748,6 @@ export class MenuBar {
       {
         type: 'item',
         label: 'About BeatBax',
-        icon: 'globe-alt',
         action: () => window.open(ABOUT_URL, '_blank', 'noopener,noreferrer'),
       },
     ];
@@ -707,13 +768,9 @@ export class MenuBar {
 
     for (const plugin of plugins) {
       const isUniversal = plugin.supportedChips.includes('*');
-      const iconName = plugin.uiContributions?.toolbarIcon
-        ?? EXPORTER_DEFAULT_ICONS[plugin.id]
-        ?? 'document-arrow-down';
       const ext = plugin.extension.startsWith('.') ? plugin.extension : `.${plugin.extension}`;
       const item: MenuItemDef = {
         type: 'item',
-        icon: iconName,
         label: `Export as ${plugin.label} (${ext})`,
         action: () => this.opts.onExport?.(plugin.id),
       };
@@ -761,7 +818,6 @@ export class MenuBar {
     return EXAMPLE_SONG_GROUPS.map(group => ({
       type: 'submenu' as const,
       label: group.group,
-      icon: 'cpu-chip',
       children: group.songs.map(s => ({
         type: 'item' as const,
         label: s.label,
@@ -810,6 +866,13 @@ export class MenuBar {
     panel.hidden = false;
     btn.setAttribute('aria-expanded', 'true');
     btn.classList.add('bb-menu__trigger--active');
+    if (id === 'view' || id === 'help') this.refreshPanelToggleChecks();
+  }
+
+  private firstFocusableMenuItem(panel: HTMLElement): HTMLElement | null {
+    return panel.querySelector<HTMLElement>(
+      '[role="menuitem"]:not([aria-disabled="true"]), [role="menuitemcheckbox"]:not([aria-disabled="true"])',
+    );
   }
 
   private closeAll(): void {
@@ -827,9 +890,13 @@ export class MenuBar {
   // ─── Keyboard navigation inside a panel ───────────────────────────────────────
 
   private handleItemKeydown(e: KeyboardEvent, current: HTMLElement): void {
-    const panel = current.closest<HTMLElement>('.bb-menu__panel');
+    const panel = current.closest<HTMLElement>('.bb-menu__panel, .bb-menu__sub-panel');
     if (!panel) return;
-    const items = Array.from(panel.querySelectorAll<HTMLElement>('[role="menuitem"]:not([aria-disabled="true"])'));
+    const items = Array.from(
+      panel.querySelectorAll<HTMLElement>(
+        '[role="menuitem"]:not([aria-disabled="true"]), [role="menuitemcheckbox"]:not([aria-disabled="true"])',
+      ),
+    );
     const idx = items.indexOf(current);
 
     if (e.key === 'ArrowDown') {
@@ -968,6 +1035,14 @@ export class MenuBar {
     // who emitted it (keyboard shortcuts, toolbar buttons, other components).
     this.opts.eventBus.on('panel:toggled', ({ panel, visible }) => {
       this.panelVisible.set(panel, visible);
+      const menuId = PANEL_CHECK_IDS[panel];
+      if (menuId) this.setItemChecked(menuId, this.isPanelEffectivelyVisible(panel));
+      if (panel === 'ai-assistant') {
+        this.setItemChecked(
+          'ai-assistant',
+          isFeatureEnabled(FeatureFlag.AI_ASSISTANT) && visible,
+        );
+      }
     });
 
     // Disable / re-enable feature-gated menu items when the flag is toggled.
@@ -976,6 +1051,14 @@ export class MenuBar {
       if (flag === FeatureFlag.PATTERN_GRID)    this.setItemEnabled('pattern-grid-toggle', enabled);
       if (flag === FeatureFlag.AI_ASSISTANT)    this.setItemEnabled('ai-assistant', enabled);
       if (flag === FeatureFlag.CHANNEL_MIXER)   this.setItemEnabled('channel-mixer-toggle', enabled);
+      if (
+        flag === FeatureFlag.SONG_VISUALIZER
+        || flag === FeatureFlag.PATTERN_GRID
+        || flag === FeatureFlag.AI_ASSISTANT
+        || flag === FeatureFlag.CHANNEL_MIXER
+      ) {
+        this.refreshPanelToggleChecks();
+      }
     });
   }
 
@@ -1001,8 +1084,8 @@ interface ActionItemDef extends BaseItemDef {
   type: 'item';
   label: string;
   shortcut?: string;
-  /** Optional heroicon name to prefix the label. */
-  icon?: string;
+  /** Show a checkmark in the left gutter when toggled on. */
+  checkable?: boolean;
   action: () => void;
 }
 
@@ -1013,8 +1096,6 @@ interface SeparatorDef {
 interface SubmenuItemDef extends BaseItemDef {
   type: 'submenu';
   label: string;
-  /** Optional heroicon name to prefix the label. */
-  icon?: string;
   /** Static children (resolved at render time). */
   children?: MenuItemDef[];
   /** Dynamic children (resolved each time the submenu opens). */

--- a/apps/web-ui/src/ui/toolbar.ts
+++ b/apps/web-ui/src/ui/toolbar.ts
@@ -52,8 +52,6 @@ export interface ToolbarOptions {
   onRedo?: () => void;
   /** Format / auto-indent the document. */
   //onFormat?: () => void;
-  /** Select all text in the editor. */
-  onSelectAll?: () => void;
   /** Toggle dark/light theme. */
   onToggleTheme?: () => void;
   /** Toggle word-wrap. Receives the new enabled state. */
@@ -115,14 +113,11 @@ export class Toolbar {
         <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-redo" title="Redo (Ctrl+Y)">
           ${icon('arrow-uturn-right', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Redo</span>
         </button>
-        <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-fold-comments" title="Fold/Unfold All Comments">
-          ${icon('hashtag', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Fold</span>
+        <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-wrap" title="Toggle word wrap">${icon('arrow-path', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Wrap</span></button>
+        <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-fold-comments" title="Fold All Comments">
+          ${icon('chevron-down', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Fold</span>
         </button>
         <!-- <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-format" title="Format document">{ } <span class="bb-toolbar__btn-label">Format</span></button> -->
-        <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-wrap" title="Toggle word wrap">${icon('arrow-path', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Wrap</span></button>
-        <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-selectall" title="Select All (Ctrl+A)">
-          ${icon('bars-3', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Select All</span>
-        </button>
       </div>
 
       <div class="bb-toolbar__separator bb-toolbar__sep--edit" aria-hidden="true"></div>
@@ -207,7 +202,7 @@ export class Toolbar {
 
   private attachEvents(): void {
         const { eventBus, onLoad, onExport, onVerify,
-          onNew, onSave, onUndo, onRedo, /*onFormat,*/ onSelectAll,
+          onNew, onSave, onUndo, onRedo, /*onFormat,*/
           onToggleTheme, onToggleWrap, onToggleFoldComments,
           onOpenFileReadStart, onOpenFileReadEnd,
           onBeforeOpenFile, onBeforeExampleLoad } = this.options;
@@ -382,15 +377,13 @@ export class Toolbar {
       });
     }
 
-    // Undo / Redo / Format / Select All
+    // Undo / Redo / Format
     const undoBtn = this.el.querySelector<HTMLButtonElement>('#tb-undo');
     if (undoBtn) undoBtn.addEventListener('click', () => onUndo?.());
     const redoBtn = this.el.querySelector<HTMLButtonElement>('#tb-redo');
     if (redoBtn) redoBtn.addEventListener('click', () => onRedo?.());
     //const formatBtn = this.el.querySelector<HTMLButtonElement>('#tb-format');
     //if (formatBtn) formatBtn.addEventListener('click', () => onFormat?.());
-    const selectAllBtn = this.el.querySelector<HTMLButtonElement>('#tb-selectall');
-    if (selectAllBtn) selectAllBtn.addEventListener('click', () => onSelectAll?.());
 
     // Theme toggle
     this._themeToggleBtn = this.el.querySelector<HTMLButtonElement>('#tb-theme') ?? undefined;
@@ -464,7 +457,14 @@ export class Toolbar {
   /** Set the active state of the fold-comments toggle. */
   setFoldCommentsActive(folded: boolean): void {
     this._foldCommentsEnabled = folded;
-    this._foldCommentsToggleBtn?.classList.toggle('bb-toolbar__btn--active', folded);
+    if (this._foldCommentsToggleBtn) {
+      const iconClass = 'w-4 h-4 inline-block align-text-bottom';
+      this._foldCommentsToggleBtn.innerHTML = folded
+        ? `${icon('chevron-up', iconClass)} <span class="bb-toolbar__btn-label">Fold</span>`
+        : `${icon('chevron-down', iconClass)} <span class="bb-toolbar__btn-label">Fold</span>`;
+      this._foldCommentsToggleBtn.title = folded ? 'Unfold All Comments' : 'Fold All Comments';
+      this._foldCommentsToggleBtn.classList.toggle('bb-toolbar__btn--active', folded);
+    }
   }
 
   /** Switch between icons+labels and icons-only display style. */

--- a/apps/web-ui/src/utils/local-storage.ts
+++ b/apps/web-ui/src/utils/local-storage.ts
@@ -40,6 +40,8 @@ export const StorageKey = {
   AUTO_SAVE: 'editor.autoSave',
   /** Word wrap enabled flag (boolean). */
   WORD_WRAP: 'editor.wordWrap',
+  /** Fold all block comments enabled flag (boolean). */
+  FOLD_COMMENTS: 'editor.foldComments',
   /** CodeLens previews enabled (boolean). */
   CODELENS: 'editor.codelens',
   /** Beat decorations enabled (boolean). */

--- a/apps/web-ui/tests/__mocks__/engine-chips.ts
+++ b/apps/web-ui/tests/__mocks__/engine-chips.ts
@@ -1,16 +1,45 @@
 /** Jest mock for @beatbax/engine/chips — avoids loading ESM dist in tests. */
 
+import { gameboyUIContributions } from '../../../../packages/engine/src/chips/gameboy/ui-contributions';
+import { nesUIContributions } from '../../../../packages/engine/src/chips/nes/ui-contributions';
+import { smsUIContributions } from '../../../../packages/plugins/chip-sms/src/ui-contributions';
+
+/** Minimal spectrum hover docs for tests (full plugin imports platform-profiles.js). */
+const spectrumTestHoverDocs = {
+  type: [
+    '**Channel type** — selects which AY-3-8912 tone/noise voice this instrument drives.',
+    '```\ntype=<tone1|tone2|tone3>\n```',
+  ].join('\n'),
+  vol: [
+    '**vol** — Fixed channel amplitude (0–15).',
+    '',
+    'Use when you do not need envelope shaping.',
+  ].join('\n'),
+  tone1: '**Tone 1** — AY-3-8912 square-wave channel A (BeatBax channel 1).',
+  tone2: '**Tone 2** — AY-3-8912 square-wave channel B (BeatBax channel 2).',
+  tone3: '**Tone 3** — AY-3-8912 square-wave channel C (BeatBax channel 3).',
+  vol_env: '**vol_env** — Hardware envelope program on AY R11–R13.',
+  tone_mix: '**tone_mix** — Enable noise mixing for this channel (R7 mixer bit).',
+  noise_rate: '**noise_rate** — AY R6 noise period (0–31).',
+};
+
 const aliases: Record<string, string> = {
   gb: 'gameboy',
   dmg: 'gameboy',
   famicom: 'nes',
+  gg: 'sms',
+  gamegear: 'sms',
   ay: 'spectrum-128',
   spectrum: 'spectrum-128',
   cpc: 'spectrum-128',
   'amstrad-cpc': 'spectrum-128',
 };
 
-const plugins = new Map<string, { effects?: Record<string, unknown>; uiContributions?: { hoverDocs?: Record<string, string> } }>();
+const plugins = new Map<string, {
+  effects?: Record<string, unknown>;
+  supportsPerChannelVolume?: boolean;
+  uiContributions?: { hoverDocs?: Record<string, string> };
+}>();
 
 export class ChipRegistry {
   resolve(name: string): string {
@@ -25,16 +54,21 @@ export class ChipRegistry {
     return plugins.has(this.resolve(name));
   }
 
-  register(plugin: { name: string; effects?: Record<string, unknown>; uiContributions?: { hoverDocs?: Record<string, string> } }) {
+  register(plugin: {
+    name: string;
+    effects?: Record<string, unknown>;
+    supportsPerChannelVolume?: boolean;
+    uiContributions?: { hoverDocs?: Record<string, string> };
+  }) {
     plugins.set(plugin.name, plugin);
   }
 
   list(): string[] {
-    return ['gameboy', 'gb', 'dmg', 'nes', 'spectrum-128', 'ay', 'spectrum', 'cpc', 'amstrad-cpc'];
+    return ['gameboy', 'gb', 'dmg', 'nes', 'sms', 'gg', 'gamegear', 'spectrum-128', 'ay', 'spectrum', 'cpc', 'amstrad-cpc'];
   }
 
   listCanonical(): string[] {
-    return ['gameboy', 'nes', 'spectrum-128'];
+    return ['gameboy', 'nes', 'sms', 'spectrum-128'];
   }
 
   aliasesFor(_canonical: string): string[] {
@@ -43,3 +77,16 @@ export class ChipRegistry {
 }
 
 export const chipRegistry = new ChipRegistry();
+
+chipRegistry.register({
+  name: 'gameboy',
+  supportsPerChannelVolume: false,
+  uiContributions: gameboyUIContributions,
+});
+chipRegistry.register({
+  name: 'nes',
+  supportsPerChannelVolume: true,
+  uiContributions: nesUIContributions,
+});
+chipRegistry.register({ name: 'sms', uiContributions: smsUIContributions });
+chipRegistry.register({ name: 'spectrum-128', uiContributions: { hoverDocs: spectrumTestHoverDocs } });

--- a/apps/web-ui/tests/__mocks__/engine-chips.ts
+++ b/apps/web-ui/tests/__mocks__/engine-chips.ts
@@ -21,6 +21,12 @@ const spectrumTestHoverDocs = {
   vol_env: '**vol_env** — Hardware envelope program on AY R11–R13.',
   tone_mix: '**tone_mix** — Enable noise mixing for this channel (R7 mixer bit).',
   noise_rate: '**noise_rate** — AY R6 noise period (0–31).',
+  chipRegion: [
+    '**chip cpc** — Amstrad CPC platform (1 MHz AY clock).',
+    '',
+    '| Chip directive | Machine | AY Clock |',
+    '| `chip cpc` | Amstrad CPC 464/6128 | 1,000,000 Hz |',
+  ].join('\n'),
 };
 
 const aliases: Record<string, string> = {

--- a/apps/web-ui/tests/beatbax-language.hover.test.ts
+++ b/apps/web-ui/tests/beatbax-language.hover.test.ts
@@ -156,7 +156,7 @@ describe('BeatBax Monaco hover provider', () => {
   test('shows tier-2 transform hover for lag in a chained seq modifier', () => {
     const hoverProvider = getHoverProvider();
     const line = 'seq demo_lag = lead_core:rot(1):lag(1)';
-    const lagColumn = line.indexOf('lag') + 2;
+    const lagColumn = line.lastIndexOf('lag') + 2;
 
     const model = makeMultilineModel([line]);
     const hover = hoverProvider.provideHover(model, { lineNumber: 1, column: lagColumn });
@@ -212,7 +212,7 @@ describe('BeatBax Monaco hover provider', () => {
     const rotModel = makeMultilineModel([rotLine]);
     const rotHover = hoverProvider.provideHover(rotModel, {
       lineNumber: 1,
-      column: rotLine.indexOf('rot') + 2,
+      column: rotLine.lastIndexOf('rot') + 2,
     });
     expect(rotHover?.contents[0].value).toContain('Rotate');
     expect(rotHover?.contents[0].value).toContain('[C4 D4 E4 G4]');

--- a/apps/web-ui/tests/beatbax-language.nes-macro-hover.test.ts
+++ b/apps/web-ui/tests/beatbax-language.nes-macro-hover.test.ts
@@ -1,6 +1,7 @@
 import * as monaco from 'monaco-editor';
 import {
   parseNesMacroAtPosition,
+  renderAttenuationSparkline,
   renderNesMacroSparkline,
   ParsedNesMacro,
   registerBeatBaxLanguage,
@@ -168,6 +169,27 @@ describe('renderNesMacroSparkline', () => {
   });
 });
 
+describe('renderAttenuationSparkline', () => {
+  it('maps SMS attenuation decay to a falling loudness sparkline', () => {
+    const chars = ' ▁▂▃▄▅▆▇█';
+    const line = renderAttenuationSparkline([0, 3, 6, 9, 12, 15]);
+    expect(line).toHaveLength(6);
+    const indices = [...line].map((c) => chars.indexOf(c));
+    expect(indices[0]).toBeGreaterThan(indices[indices.length - 1]);
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeLessThanOrEqual(indices[i - 1]);
+    }
+  });
+
+  it('renders loudest attenuation (0) as full block', () => {
+    expect(renderAttenuationSparkline([0])).toBe('█');
+  });
+
+  it('renders silent attenuation (15) as empty', () => {
+    expect(renderAttenuationSparkline([15])).toBe(' ');
+  });
+});
+
 // ── provideHover integration ──────────────────────────────────────────────────
 
 describe('provideHover — NES macro hover', () => {
@@ -252,6 +274,31 @@ describe('provideHover — NES macro hover', () => {
     expect(hover).not.toBeNull();
     expect(hover.contents[0].value).toContain('Pitch envelope');
     expect(hover.contents[2].value).toContain('multiplied by 16');
+  });
+
+  it('returns SMS vol_env hover with inverted loudness sparkline', () => {
+    eventBus.emit('parse:success', {
+      ast: { chip: 'sms', insts: {}, pats: {}, seqs: {} },
+      resolvedAst: undefined,
+      song: null,
+    });
+    const provider = getHoverProvider();
+    const line = 'inst lead type=tone1 vol=0 vol_env=[0,3,6,9,12,15]';
+    const col = colOf(line, '0,3,6');
+
+    const hover = provider.provideHover(makeModel(line), pos(col));
+
+    expect(hover).not.toBeNull();
+    expect(hover.contents[0].value).toContain('SMS volume macro');
+    expect(hover.contents[2].value).toContain('perceived loudness');
+
+    const sparkBlock = hover.contents[1].value;
+    const sparkline = sparkBlock.match(/```text\n([\s\S]*?)\n```/)?.[1] ?? '';
+    const chars = ' ▁▂▃▄▅▆▇█';
+    const indices = [...sparkline.trim()].map((c) => chars.indexOf(c));
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeLessThanOrEqual(indices[i - 1]);
+    }
   });
 
   it('returns duty_env hover with duty cycle labels', () => {

--- a/apps/web-ui/tests/code-actions.test.ts
+++ b/apps/web-ui/tests/code-actions.test.ts
@@ -293,11 +293,11 @@ describe('suggestQuickFixes', () => {
       model,
       marker('seq', 5, 30),
     );
-    expect(fixes[0].title).toBe("Use sequence 'main'");
+    expect(fixes[0].title).toBe("Use pattern 'main'");
     expect(editText(fixes[0])).toBe('main');
     expect(fixes.map((f) => f.title)).toEqual(
       expect.arrayContaining([
-        "Use sequence 'main'",
+        "Use pattern 'main'",
         "Create pattern 'mainn'",
         "Create sequence 'mainn'",
       ]),

--- a/apps/web-ui/tests/codelens-preview.test.ts
+++ b/apps/web-ui/tests/codelens-preview.test.ts
@@ -1,5 +1,12 @@
+const mockParseWithPeggy = jest.fn();
+
+jest.mock('@beatbax/engine/parser', () => ({
+  parse: (source?: string) => ({ pats: {}, patsOrder: [], insts: {}, seqs: {}, channels: [], bpm: 120 }),
+  parseWithPeggy: (...args: unknown[]) => mockParseWithPeggy(...args),
+}));
+
 import { EventBus } from '../src/utils/event-bus';
-import { resolveAuditionInstrumentForLine, setupCodeLensPreview } from '../src/editor/codelens-preview';
+import { resolveAuditionInstrumentForLine, parseSourceForPreview, setupCodeLensPreview } from '../src/editor/codelens-preview';
 import * as monaco from 'monaco-editor';
 
 describe('CodeLens Preview provider', () => {
@@ -92,5 +99,31 @@ describe('CodeLens Preview provider', () => {
     };
 
     expect(resolveAuditionInstrumentForLine('inst arpLead type=pulse1 duty=50', ast)).toBe('arpLead');
+  });
+
+  it('parseSourceForPreview returns partial AST when empty pat is a syntax error', () => {
+    mockParseWithPeggy.mockReturnValue({
+      hasErrors: true,
+      errors: [{ message: "Pattern statement is incomplete: missing pattern content after '='." }],
+      ast: {
+        chip: 'nes',
+        insts: { lead: { type: 'pulse1' } },
+        pats: {},
+        channels: [],
+      },
+    });
+    const ast = parseSourceForPreview('chip nes\ninst lead type=pulse1\npat test =\n');
+    expect(ast).not.toBeNull();
+    expect(Object.keys(ast.insts)).toContain('lead');
+    expect(ast.chip).toBe('nes');
+  });
+
+  it('parseSourceForPreview returns null when source has no preview context', () => {
+    mockParseWithPeggy.mockReturnValue({
+      hasErrors: true,
+      errors: [{ message: "Pattern statement is incomplete: missing pattern content after '='." }],
+      ast: { pats: {}, insts: {}, channels: [] },
+    });
+    expect(parseSourceForPreview('pat test =')).toBeNull();
   });
 });

--- a/apps/web-ui/tests/editor-integration.test.ts
+++ b/apps/web-ui/tests/editor-integration.test.ts
@@ -250,8 +250,8 @@ describe('Editor Integration', () => {
       eventBus.on('validation:warnings', warningHandler);
 
       const warnings = [
-        { component: 'resolver', message: 'Undefined instrument: snare', loc: { line: 5 } },
-        { component: 'resolver', message: 'Undefined pattern: melody', loc: { line: 10 } },
+        { component: 'resolver', message: 'Undefined instrument: snare', loc: { start: { line: 5 } } },
+        { component: 'resolver', message: 'Undefined pattern: melody', loc: { start: { line: 10 } } },
       ];
 
       eventBus.emit('validation:warnings', { warnings });

--- a/apps/web-ui/tests/event-bus.test.ts
+++ b/apps/web-ui/tests/event-bus.test.ts
@@ -36,7 +36,7 @@ describe('EventBus', () => {
       bus.on('playback:started', callback1);
       bus.on('playback:started', callback2);
       
-      bus.emit('playback:started', undefined);
+      bus.emit('playback:started', {});
       
       expect(callback1).toHaveBeenCalledTimes(1);
       expect(callback2).toHaveBeenCalledTimes(1);
@@ -105,12 +105,12 @@ describe('EventBus', () => {
       const callback = jest.fn();
       const unsubscribe = bus.on('playback:started', callback);
       
-      bus.emit('playback:started', undefined);
+      bus.emit('playback:started', {});
       expect(callback).toHaveBeenCalledTimes(1);
       
       unsubscribe();
       
-      bus.emit('playback:started', undefined);
+      bus.emit('playback:started', {});
       expect(callback).toHaveBeenCalledTimes(1); // Still 1, not called again
     });
   });
@@ -126,7 +126,7 @@ describe('EventBus', () => {
       bus.clear();
       
       bus.emit('editor:changed', { content: 'test' });
-      bus.emit('playback:started', undefined);
+      bus.emit('playback:started', {});
       
       expect(callback1).not.toHaveBeenCalled();
       expect(callback2).not.toHaveBeenCalled();

--- a/apps/web-ui/tests/gm-programs.test.ts
+++ b/apps/web-ui/tests/gm-programs.test.ts
@@ -1,0 +1,67 @@
+import * as monaco from 'monaco-editor';
+import {
+  buildGmHoverMarkdown,
+  getGmProgramName,
+  parseGmAtPosition,
+} from '../src/editor/gm-programs';
+import { registerBeatBaxLanguage } from '../src/editor/beatbax-language';
+
+describe('GM program helpers', () => {
+  test('getGmProgramName returns standard patch names', () => {
+    expect(getGmProgramName(80)).toBe('Lead 1 (square)');
+    expect(getGmProgramName(81)).toBe('Lead 2 (sawtooth)');
+    expect(getGmProgramName(34)).toBe('Electric Bass (pick)');
+    expect(getGmProgramName(128)).toBeNull();
+    expect(getGmProgramName(-1)).toBeNull();
+  });
+
+  test('buildGmHoverMarkdown includes family and export note', () => {
+    const md = buildGmHoverMarkdown(81);
+    expect(md).toContain('Lead 2 (sawtooth)');
+    expect(md).toContain('Synth Lead');
+    expect(md).toContain('MIDI export');
+  });
+
+  test('parseGmAtPosition matches gm= on inst lines only', () => {
+    const line = 'inst melody type=pulse1 duty=50 env={"level":12,"direction":"down","period":1,"format":"gb"} gm=81';
+    const gmColumn = line.indexOf('81') + 1;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    expect(parseGmAtPosition(model, { lineNumber: 1, column: gmColumn })?.program).toBe(81);
+
+    const seqModel = {
+      getLineContent: jest.fn(() => 'seq demo = pat:gm=81'),
+    } as unknown as monaco.editor.ITextModel;
+    expect(parseGmAtPosition(seqModel, { lineNumber: 1, column: 14 })).toBeNull();
+  });
+});
+
+describe('BeatBax Monaco hover provider — gm=', () => {
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  test('shows GM patch name when hovering gm= value on inst line', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst lead type=pulse1 duty=50 gm=81';
+    const column = line.indexOf('81') + 1;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => null),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+
+    expect(hover).toBeTruthy();
+    expect(hover.contents[0].value).toContain('Lead 2 (sawtooth)');
+    expect(hover.contents[0].value).toContain('Program **81**');
+  });
+});

--- a/apps/web-ui/tests/inst-note-hover.test.ts
+++ b/apps/web-ui/tests/inst-note-hover.test.ts
@@ -1,0 +1,87 @@
+import * as monaco from 'monaco-editor';
+import {
+  buildNoteHoverMarkdown,
+  getGmDrumName,
+  noteToUgeIndex,
+  parseNoteAtPosition,
+} from '../src/editor/inst-note-hover';
+import { registerBeatBaxLanguage } from '../src/editor/beatbax-language';
+
+describe('inst note= hover helpers', () => {
+  test('noteToUgeIndex matches hUGE export offset', () => {
+    expect(noteToUgeIndex(36)).toBe(0); // C2 → index 0
+    expect(noteToUgeIndex(60)).toBe(24); // C4
+    expect(noteToUgeIndex(96)).toBe(60); // C7
+  });
+
+  test('getGmDrumName returns standard drum labels', () => {
+    expect(getGmDrumName(38)).toBe('Acoustic Snare');
+    expect(getGmDrumName(42)).toBe('Closed Hi-Hat');
+    expect(getGmDrumName(34)).toBeNull();
+  });
+
+  test('parseNoteAtPosition matches note= on inst lines only', () => {
+    const line = 'inst snare type=noise gb:width=7 env=13,down note=C7';
+    const noteColumn = line.indexOf('C7') + 1;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const parsed = parseNoteAtPosition(model, { lineNumber: 1, column: noteColumn });
+    expect(parsed?.noteName).toBe('C7');
+    expect(parsed?.instType).toBe('noise');
+
+    const seqModel = {
+      getLineContent: jest.fn(() => 'pat drums = note=C7'),
+    } as unknown as monaco.editor.ITextModel;
+    expect(parseNoteAtPosition(seqModel, { lineNumber: 1, column: 16 })).toBeNull();
+  });
+
+  test('buildNoteHoverMarkdown includes MIDI, frequency, and noise guidance', () => {
+    const md = buildNoteHoverMarkdown({
+      noteName: 'C7',
+      instType: 'noise',
+      instLine: 'inst snare type=noise note=C7',
+      range: {
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: 1,
+        endColumn: 10,
+      },
+    }, 'gameboy');
+
+    expect(md).toContain('MIDI **96**');
+    expect(md).toContain('Hz');
+    expect(md).toContain('hUGE export index: **60**');
+    expect(md).toContain('noise');
+  });
+});
+
+describe('BeatBax Monaco hover provider — note=', () => {
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  test('shows note details when hovering note= on percussion inst line', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst hihat type=noise gb:width=15 env=6,down note=E7';
+    const column = line.indexOf('E7') + 1;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => null),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+
+    expect(hover).toBeTruthy();
+    expect(hover.contents[0].value).toContain('Default hit note');
+    expect(hover.contents[0].value).toContain('E7');
+    expect(hover.contents[0].value).toContain('MIDI **100**');
+  });
+});

--- a/apps/web-ui/tests/inst-property-hover.test.ts
+++ b/apps/web-ui/tests/inst-property-hover.test.ts
@@ -209,6 +209,29 @@ describe('Spectrum-128 inst property hovers', () => {
     expect(hover?.contents[0].value).toContain('Volume 10');
     expect(hover?.contents[0].value).toContain('15 = loudest');
   });
+
+  test('buildInstPropertyKeywordHover explains camelCase chipRegion= property name', () => {
+    const line = 'inst kick type=tone3 chipRegion=cpc vol=10';
+    const column = line.indexOf('chipRegion') + 5;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyKeywordHover(model, { lineNumber: 1, column }, 'spectrum-128');
+    expect(hover?.contents[0].value).toContain('Amstrad CPC');
+  });
+
+  test('buildInstPropertyHover explains chipRegion= enum value from chip hoverDocs', () => {
+    const line = 'inst kick type=tone3 chipRegion=cpc vol=10';
+    const column = line.indexOf('cpc') + 2;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyHover(model, { lineNumber: 1, column }, 'spectrum-128');
+    expect(hover?.contents[0].value).toContain('chipRegion=cpc');
+    expect(hover?.contents[0].value).toContain('Amstrad CPC');
+  });
 });
 
 describe('BeatBax Monaco hover provider — Spectrum-128 inst properties', () => {

--- a/apps/web-ui/tests/inst-property-hover.test.ts
+++ b/apps/web-ui/tests/inst-property-hover.test.ts
@@ -1,0 +1,262 @@
+import * as monaco from 'monaco-editor';
+import { chipRegistry } from '@beatbax/engine/chips';
+import { buildInstPropertyHover, buildInstPropertyKeywordHover } from '../src/editor/inst-property-hover';
+import { registerBeatBaxLanguage } from '../src/editor/beatbax-language';
+import { eventBus } from '../src/utils/event-bus';
+
+describe('NES inst property hovers', () => {
+  test('chip hoverDocs include type, duty, and vol', () => {
+    const docs = chipRegistry.get('nes')?.uiContributions?.hoverDocs ?? {};
+    expect(docs.type).toContain('Channel type');
+    expect(docs.duty).toContain('Duty cycle');
+    expect(docs.vol).toContain('Constant volume');
+  });
+
+  test('buildInstPropertyHover explains duty= value on inst line', () => {
+    const line = 'inst lead type=pulse1 duty=50 env=13,down';
+    const column = line.indexOf('50') + 1;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyHover(model, { lineNumber: 1, column }, 'nes');
+    expect(hover?.contents[0].value).toContain('Duty cycle 50%');
+    expect(hover?.contents[0].value).toContain('Balanced');
+  });
+
+  test('buildInstPropertyHover explains vol= value on inst line', () => {
+    const line = 'inst lead type=pulse1 duty=25 vol=10';
+    const column = line.indexOf('10') + 2;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyHover(model, { lineNumber: 1, column }, 'nes');
+    expect(hover?.contents[0].value).toContain('Volume 10');
+    expect(hover?.contents[0].value).toContain('67%');
+  });
+});
+
+describe('BeatBax Monaco hover provider — NES inst properties', () => {
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    eventBus.emit('parse:success', {
+      ast: { chip: 'nes', insts: {}, pats: {}, seqs: {} },
+    });
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  test('shows type doc when hovering type on NES inst line', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst lead type=pulse1 duty=25 vol=10';
+    const column = line.indexOf('type') + 2;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({
+        word: 'type',
+        startColumn: line.indexOf('type') + 1,
+        endColumn: line.indexOf('type') + 5,
+      })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+    expect(hover?.contents[0].value).toContain('Channel type');
+  });
+
+  test('shows duty doc when hovering duty keyword on NES inst line', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst lead type=pulse1 duty=25 env=13,down';
+    const column = line.indexOf('duty') + 2;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({
+        word: 'duty',
+        startColumn: line.indexOf('duty') + 1,
+        endColumn: line.indexOf('duty') + 5,
+      })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+    expect(hover?.contents[0].value).toContain('Duty cycle');
+  });
+});
+
+describe('SMS inst property hovers', () => {
+  test('chip hoverDocs include type and vol', () => {
+    const docs = chipRegistry.get('sms')?.uiContributions?.hoverDocs ?? {};
+    expect(docs.type).toContain('Channel type');
+    expect(docs.vol).toContain('attenuation');
+  });
+
+  test('buildInstPropertyHover explains SMS vol= with attenuation semantics', () => {
+    const line = 'inst lead type=tone1 vol=10';
+    const column = line.indexOf('10') + 1;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyHover(model, { lineNumber: 1, column }, 'sms');
+    expect(hover?.contents[0].value).toContain('Volume 10');
+    expect(hover?.contents[0].value).toContain('0 = loudest');
+  });
+
+  test('buildInstPropertyHover explains noise_rate= on SMS inst line', () => {
+    const line = 'inst kick type=noise noise_mode=white noise_rate=2 vol=5';
+    const column = line.indexOf('noise_rate=2') + 'noise_rate='.length + 1;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyHover(model, { lineNumber: 1, column }, 'sms');
+    expect(hover?.contents[0].value).toContain('noise_rate=2');
+    expect(hover?.contents[0].value).toContain('Lowest frequency');
+  });
+});
+
+describe('BeatBax Monaco hover provider — SMS inst properties', () => {
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    eventBus.emit('parse:success', {
+      ast: { chip: 'sms', insts: {}, pats: {}, seqs: {} },
+    });
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  test('shows type doc when hovering type on SMS inst line', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst lead type=tone1 vol=10';
+    const column = line.indexOf('type') + 2;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({
+        word: 'type',
+        startColumn: line.indexOf('type') + 1,
+        endColumn: line.indexOf('type') + 5,
+      })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+    expect(hover?.contents[0].value).toContain('Channel type');
+  });
+
+  test('shows vol doc when hovering vol keyword on SMS inst line', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst lead type=tone1 vol=10';
+    const column = line.indexOf('vol') + 2;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({
+        word: 'vol',
+        startColumn: line.indexOf('vol') + 1,
+        endColumn: line.indexOf('vol') + 4,
+      })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+    expect(hover?.contents[0].value).toContain('attenuation');
+  });
+});
+
+describe('Spectrum-128 inst property hovers', () => {
+  test('chip hoverDocs include type and vol keywords', () => {
+    const docs = chipRegistry.get('spectrum-128')?.uiContributions?.hoverDocs ?? {};
+    expect(docs.type).toContain('Channel type');
+    expect(docs.vol).toContain('Fixed channel amplitude');
+  });
+
+  test('buildInstPropertyKeywordHover explains type= property name', () => {
+    const line = 'inst tone1 type=tone1 vol=10';
+    const column = line.indexOf('type') + 2;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyKeywordHover(model, { lineNumber: 1, column }, 'spectrum-128');
+    expect(hover?.contents[0].value).toContain('Channel type');
+  });
+
+  test('buildInstPropertyKeywordHover explains vol= property name', () => {
+    const line = 'inst tone1 type=tone1 vol=10';
+    const column = line.indexOf('vol') + 2;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyKeywordHover(model, { lineNumber: 1, column }, 'spectrum-128');
+    expect(hover?.contents[0].value).toContain('Fixed channel amplitude');
+  });
+
+  test('buildInstPropertyHover still explains vol= value', () => {
+    const line = 'inst tone1 type=tone1 vol=10';
+    const column = line.indexOf('10') + 1;
+    const model = {
+      getLineContent: jest.fn(() => line),
+    } as unknown as monaco.editor.ITextModel;
+
+    const hover = buildInstPropertyHover(model, { lineNumber: 1, column }, 'spectrum-128');
+    expect(hover?.contents[0].value).toContain('Volume 10');
+    expect(hover?.contents[0].value).toContain('15 = loudest');
+  });
+});
+
+describe('BeatBax Monaco hover provider — Spectrum-128 inst properties', () => {
+  function getHoverProvider() {
+    registerBeatBaxLanguage();
+    eventBus.emit('parse:success', {
+      ast: { chip: 'spectrum-128', insts: { tone1: { type: 'tone1', vol: 10 } }, pats: {}, seqs: {} },
+    });
+    const call = (monaco.languages.registerHoverProvider as jest.Mock).mock.calls.find(
+      ([lang]) => lang === 'beatbax',
+    );
+    expect(call).toBeDefined();
+    return call?.[1];
+  }
+
+  test('shows type doc when hovering type keyword (not only the value)', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst tone1 type=tone1 vol=10';
+    const column = line.indexOf('type') + 2;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({
+        word: 'type',
+        startColumn: line.indexOf('type') + 1,
+        endColumn: line.indexOf('type') + 5,
+      })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+    expect(hover?.contents[0].value).toContain('Channel type');
+  });
+
+  test('shows vol doc when hovering vol keyword (not only the value)', () => {
+    const hoverProvider = getHoverProvider();
+    const line = 'inst tone1 type=tone1 vol=10';
+    const column = line.indexOf('vol') + 2;
+
+    const model = {
+      getLineContent: jest.fn(() => line),
+      getWordAtPosition: jest.fn(() => ({
+        word: 'vol',
+        startColumn: line.indexOf('vol') + 1,
+        endColumn: line.indexOf('vol') + 4,
+      })),
+    } as any;
+
+    const hover = hoverProvider.provideHover(model, { lineNumber: 1, column });
+    expect(hover?.contents[0].value).toContain('Fixed channel amplitude');
+  });
+});

--- a/apps/web-ui/tests/midi-step-entry.test.ts
+++ b/apps/web-ui/tests/midi-step-entry.test.ts
@@ -13,6 +13,7 @@
 import {
   midiNoteToName,
   formatNoteToken,
+  prefixSpacingBeforeInsert,
   isCursorInsidePatBody,
   extractNoteTokenSpans,
   durationMsToStepLength,
@@ -20,9 +21,14 @@ import {
   buildScalePitchClasses,
   scaleLockPitchClasses,
   snapMidiToPitchClasses,
+  resolveEffectNameFromLine,
+  isInstrumentDefinitionLine,
+  isEffectDefinitionLine,
+  isMidiPreviewLine,
   MidiStepEntryService,
 } from '../src/input/midi-step-entry';
 import { MidiStepEntryController } from '../src/input/midi-step-entry-controller';
+import { settingMidiInputEnabled } from '../src/stores/settings.store';
 
 // ─── midiNoteToName ───────────────────────────────────────────────────────────
 
@@ -127,6 +133,29 @@ describe('durationMsToStepLength', () => {
   it('maps 1600+ ms to step 16 (maximum)', () => {
     expect(durationMsToStepLength(1600)).toBe('16');
     expect(durationMsToStepLength(5000)).toBe('16');
+  });
+});
+
+// ─── prefixSpacingBeforeInsert ────────────────────────────────────────────────
+
+describe('prefixSpacingBeforeInsert', () => {
+  it('adds a leading space after a note token with no trailing space', () => {
+    const line = 'pat xxx = A4';
+    const col = line.length + 1;
+    expect(prefixSpacingBeforeInsert(line, col, 'C4')).toBe(' C4');
+  });
+
+  it('does not add a leading space when already preceded by whitespace', () => {
+    expect(prefixSpacingBeforeInsert('pat xxx = A4 ', 14, 'C4')).toBe('C4');
+  });
+
+  it('adds a leading space after = when cursor follows it directly', () => {
+    const line = 'pat xxx =';
+    expect(prefixSpacingBeforeInsert(line, line.length + 1, 'C4')).toBe(' C4');
+  });
+
+  it('does not add a leading space at column 1', () => {
+    expect(prefixSpacingBeforeInsert('pat xxx = A4', 1, 'C4')).toBe('C4');
   });
 });
 
@@ -256,6 +285,7 @@ describe('MidiStepEntryService', () => {
   let onNoteEntered: jest.Mock;
   let onAuditionStart: jest.Mock;
   let onAuditionStop: jest.Mock;
+  let onIdlePreview: jest.Mock;
   let onWarning: jest.Mock;
   let service: MidiStepEntryService;
 
@@ -263,11 +293,13 @@ describe('MidiStepEntryService', () => {
     onNoteEntered = jest.fn();
     onAuditionStart = jest.fn();
     onAuditionStop = jest.fn();
+    onIdlePreview = jest.fn();
     onWarning = jest.fn();
     service = new MidiStepEntryService({
       onNoteEntered,
       onAuditionStart,
       onAuditionStop,
+      onIdlePreview,
       onWarning,
     });
   });
@@ -348,6 +380,140 @@ describe('MidiStepEntryService', () => {
 
   it('isSupported() returns false in jsdom (no Web MIDI API)', () => {
     expect(MidiStepEntryService.isSupported()).toBe(false);
+  });
+
+  it('instant step entry does not audition on note-on (audition happens after insert)', () => {
+    (service as any).selectedInput = { addEventListener: () => {}, removeEventListener: () => {} };
+    service.setAuditionNotes(true);
+    service.setUseNoteDuration(false);
+    service.arm();
+    expect(service.isArmed()).toBe(true);
+
+    (service as any)._handleNoteOn(60, 100);
+
+    expect(onAuditionStart).not.toHaveBeenCalled();
+    expect(onNoteEntered).toHaveBeenCalledWith('C4', 'inherit', false);
+  });
+
+  it('hold-duration step entry auditions on note-on before insert', () => {
+    (service as any).selectedInput = { addEventListener: () => {}, removeEventListener: () => {} };
+    service.setAuditionNotes(true);
+    service.setUseNoteDuration(true);
+    service.arm();
+
+    (service as any)._handleNoteOn(60, 100);
+
+    expect(onAuditionStart).toHaveBeenCalledWith('C4');
+    expect(onNoteEntered).not.toHaveBeenCalled();
+  });
+
+  it('disarmed note-on triggers idle preview instead of step entry', () => {
+    (service as any).selectedInput = { addEventListener: () => {}, removeEventListener: () => {} };
+    expect(service.isArmed()).toBe(false);
+
+    (service as any)._handleNoteOn(60, 100);
+
+    expect(onIdlePreview).toHaveBeenCalledWith('C4');
+    expect(onNoteEntered).not.toHaveBeenCalled();
+    expect(onAuditionStart).not.toHaveBeenCalled();
+  });
+});
+
+describe('MIDI preview line detection', () => {
+  it('resolveEffectNameFromLine extracts effect name', () => {
+    expect(resolveEffectNameFromLine('effect reverb = echo:4')).toBe('reverb');
+    expect(resolveEffectNameFromLine('  effect bass_fx = volSlide:-2')).toBe('bass_fx');
+    expect(resolveEffectNameFromLine('inst melody type=pulse1')).toBeNull();
+  });
+
+  it('isMidiPreviewLine matches inst, effect, and pat body lines', () => {
+    expect(isMidiPreviewLine('inst melody type=pulse1 duty=25', 20)).toBe(true);
+    expect(isMidiPreviewLine('effect reverb = echo:4', 10)).toBe(true);
+    expect(isMidiPreviewLine('pat melody = C4 D4', 15)).toBe(true);
+    expect(isMidiPreviewLine('pat melody = C4 D4', 5)).toBe(false);
+    expect(isMidiPreviewLine('seq main', 5)).toBe(false);
+  });
+});
+
+describe('MidiStepEntryController idle preview', () => {
+  function createCursorEditor(lineText: string, column: number) {
+    const state = { lineText, position: { lineNumber: 1, column } };
+    const model = {
+      getLineContent: (_lineNumber: number) => state.lineText,
+    };
+    const editor = {
+      getModel: () => model,
+      getPosition: () => state.position,
+    };
+    return { editor, state };
+  }
+
+  beforeEach(() => {
+    settingMidiInputEnabled.set(true);
+  });
+
+  afterEach(() => {
+    settingMidiInputEnabled.set(false);
+  });
+
+  it('previews instrument on inst line when disarmed', () => {
+    const lineText = 'inst melody   type=pulse1  duty=25  env=12,flat';
+    const { editor } = createCursorEditor(lineText, 20);
+    const onAuditionNote = jest.fn();
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+      onAuditionNote,
+    });
+
+    (controller as any)._handleIdlePreview('A4');
+
+    expect(onAuditionNote).toHaveBeenCalledWith('A4');
+  });
+
+  it('previews effect on effect line when disarmed', () => {
+    const lineText = 'effect reverb = echo:4';
+    const { editor } = createCursorEditor(lineText, 10);
+    const onPreviewEffect = jest.fn();
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+      onPreviewEffect,
+    });
+
+    (controller as any)._handleIdlePreview('C4');
+
+    expect(onPreviewEffect).toHaveBeenCalledWith('reverb');
+  });
+
+  it('previews instrument on pat body when disarmed', () => {
+    const lineText = 'pat melody = C4 D4';
+    const column = lineText.indexOf('C4') + 1;
+    const { editor } = createCursorEditor(lineText, column);
+    const onAuditionNote = jest.fn();
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+      onAuditionNote,
+    });
+
+    (controller as any)._handleIdlePreview('G4');
+
+    expect(onAuditionNote).toHaveBeenCalledWith('G4');
+  });
+
+  it('previews instrument on inst line when armed instead of warning', () => {
+    const lineText = 'inst melody type=pulse1 duty=25';
+    const { editor } = createCursorEditor(lineText, 15);
+    const onAuditionNote = jest.fn();
+    const onWarning = jest.fn();
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+      onAuditionNote,
+      onWarning,
+    });
+
+    (controller as any)._insertNoteInEditor('A4', 'inherit', false);
+
+    expect(onAuditionNote).toHaveBeenCalledWith('A4');
+    expect(onWarning).not.toHaveBeenCalled();
   });
 });
 
@@ -452,5 +618,43 @@ describe('MidiStepEntryController overwrite-selection', () => {
     });
     (controller as any)._insertNoteInEditor('E4', 'inherit', false);
     expect(state.lineText).toBe('pat melody = ');
+  });
+
+  it('auditions after inserting into an empty pat line when enabled', () => {
+    const lineText = 'pat melody = ';
+    const onAuditionNote = jest.fn();
+    const { editor } = createSingleLineEditor(lineText, lineText.length + 1, lineText.length + 1);
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+      onAuditionNote,
+    });
+    controller.setAuditionNotes(true);
+    (controller as any)._insertNoteInEditor('C4', 'inherit', false);
+    expect(onAuditionNote).toHaveBeenCalledTimes(1);
+    expect(onAuditionNote).toHaveBeenCalledWith('C4');
+  });
+
+  it('does not audition after insert when audition is disabled', () => {
+    const lineText = 'pat melody = ';
+    const onAuditionNote = jest.fn();
+    const { editor } = createSingleLineEditor(lineText, lineText.length + 1, lineText.length + 1);
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+      onAuditionNote,
+    });
+    controller.setAuditionNotes(false);
+    (controller as any)._insertNoteInEditor('C4', 'inherit', false);
+    expect(onAuditionNote).not.toHaveBeenCalled();
+  });
+
+  it('inserts a leading space when cursor follows a note without trailing space', () => {
+    const lineText = 'pat xxx = A4';
+    const cursorCol = lineText.length + 1;
+    const { editor, state } = createSingleLineEditor(lineText, cursorCol, cursorCol);
+    const controller = new MidiStepEntryController({
+      getEditor: () => editor as any,
+    });
+    (controller as any)._insertNoteInEditor('C4', 'inherit', false);
+    expect(state.lineText).toBe('pat xxx = A4 C4 ');
   });
 });

--- a/apps/web-ui/tests/peggy-quick-fixes.test.ts
+++ b/apps/web-ui/tests/peggy-quick-fixes.test.ts
@@ -71,8 +71,8 @@ describe('peggyExpectedFixes', () => {
       'Expected "=" but "x=y" found.',
       { expectedLabels: ['='], found: 'x=y' },
     );
-    expect(patFixes[0].title).toBe("Replace with '='");
-    expect(patFixes.some((f) => f.title.startsWith('Insert'))).toBe(false);
+    expect(patFixes[0].title).toBe("Insert '='");
+    expect(patFixes.some((f) => f.title.startsWith('Replace'))).toBe(false);
   });
 
   test('inserts => on channel line', () => {

--- a/apps/web-ui/tests/settings-panel.test.ts
+++ b/apps/web-ui/tests/settings-panel.test.ts
@@ -20,8 +20,8 @@ import { SECTION_KEYS } from '../src/stores/settings.store';
 describe('StorageKey', () => {
   it('has new keys added for settings panel', () => {
     expect(StorageKey.TOOLBAR_STYLE).toBe('ui.toolbarStyle');
-    expect(StorageKey.CHANNEL_COMPACT).toBe('ui.channelCompact');
     expect(StorageKey.WORD_WRAP).toBe('editor.wordWrap');
+    expect(StorageKey.FOLD_COMMENTS).toBe('editor.foldComments');
     expect(StorageKey.CODELENS).toBe('editor.codelens');
     expect(StorageKey.BEAT_DECORATIONS).toBe('editor.beatDecorations');
     expect(StorageKey.FONT_SIZE).toBe('editor.fontSize');
@@ -32,7 +32,7 @@ describe('StorageKey', () => {
     expect(StorageKey.DEBUG_OVERLAY).toBe('debug.overlay');
     expect(StorageKey.DEBUG_EXPOSE_PLAYER).toBe('debug.exposePlayer');
     expect(StorageKey.FEATURE_PER_CHANNEL_ANALYSER).toBe('feature.perChannelAnalyser');
-    expect(StorageKey.FEATURE_DAW_MIXER).toBe('feature.dawMixer');
+    expect(StorageKey.FEATURE_CHANNEL_MIXER).toBe('feature.channelMixer');
     expect(StorageKey.FEATURE_PATTERN_GRID).toBe('feature.patternGrid');
     expect(StorageKey.FEATURE_HOT_RELOAD).toBe('feature.hotReload');
   });
@@ -43,7 +43,7 @@ describe('StorageKey', () => {
 describe('FeatureFlag', () => {
   it('has new flags', () => {
     expect(FeatureFlag.PER_CHANNEL_ANALYSER).toBe('feature.perChannelAnalyser');
-    expect(FeatureFlag.DAW_MIXER).toBe('feature.dawMixer');
+    expect(FeatureFlag.CHANNEL_MIXER).toBe('feature.channelMixer');
     expect(FeatureFlag.PATTERN_GRID).toBe('feature.patternGrid');
     expect(FeatureFlag.HOT_RELOAD).toBe('feature.hotReload');
   });
@@ -101,14 +101,14 @@ describe('SECTION_KEYS', () => {
   it('general section includes all panel visibility keys', () => {
     expect(SECTION_KEYS.general).toContain(StorageKey.PANEL_VIS_TOOLBAR);
     expect(SECTION_KEYS.general).toContain(StorageKey.PANEL_VIS_TRANSPORT_BAR);
-    expect(SECTION_KEYS.general).toContain(StorageKey.PANEL_VIS_DAW_MIXER);
+    expect(SECTION_KEYS.general).toContain(StorageKey.PANEL_VIS_CHANNEL_MIXER);
     expect(SECTION_KEYS.general).toContain(StorageKey.PANEL_VIS_PATTERN_GRID);
   });
 
   it('features section includes all feature flag keys', () => {
     expect(SECTION_KEYS.features).toContain(StorageKey.AI_ASSISTANT);
     expect(SECTION_KEYS.features).toContain(StorageKey.FEATURE_PER_CHANNEL_ANALYSER);
-    expect(SECTION_KEYS.features).toContain(StorageKey.FEATURE_DAW_MIXER);
+    expect(SECTION_KEYS.features).toContain(StorageKey.FEATURE_CHANNEL_MIXER);
     expect(SECTION_KEYS.features).toContain(StorageKey.FEATURE_PATTERN_GRID);
     expect(SECTION_KEYS.features).toContain(StorageKey.FEATURE_HOT_RELOAD);
   });

--- a/docs/features/virtual-piano-keyboard.md
+++ b/docs/features/virtual-piano-keyboard.md
@@ -1,0 +1,231 @@
+---
+title: "Virtual Piano Keyboard for Web UI note preview"
+status: proposed
+authors: ["GitHub Copilot"]
+created: 2026-06-05
+issue: "https://github.com/kadraman/beatbax/issues/133"
+---
+
+## Summary
+
+Add a **virtual piano keyboard** to the Web UI as an interactive note-preview surface. Instead of showing static note labels such as `C3 | C4 | C5` above the instrument, the UI shows a keyboard icon that expands into a clickable piano keyboard when activated.
+
+The keyboard supports three preview paths:
+
+- Clicking a virtual key previews that note.
+- Pressing a mapped computer-keyboard shortcut previews the same note.
+- Playing a MIDI keyboard previews the same note when MIDI input is enabled.
+
+Any active note preview highlights the corresponding virtual key so the user can see what is being triggered at a glance.
+
+This feature is designed to work cleanly with the existing **scale awareness** feature so in-scale notes can be highlighted or emphasized while out-of-scale notes can be visually distinguished.
+
+---
+
+## Problem Statement
+
+The current note-preview affordance is text-only and does not provide a strong spatial relationship between pitches and user input. That creates several limitations:
+
+- Users cannot visually explore intervals and note relationships quickly.
+- The preview UI is not consistent with the way musicians think about note entry and auditioning.
+- Computer keyboard and MIDI keyboard preview paths are not represented in the UI as a single interactive instrument.
+- Scale-aware guidance is difficult to present clearly when the preview surface is only static note labels.
+
+A virtual keyboard gives the Web UI a more direct auditioning surface for instruments, scales, and note entry workflows.
+
+---
+
+## Proposed Solution
+
+Replace the static `C3 | C4 | C5 ...` preview labels above the instrument area with a compact **keyboard icon** that opens a virtual piano keyboard.
+
+### Summary
+
+- The keyboard icon is shown in the same location where the note preview labels currently appear.
+- Clicking the icon expands the virtual keyboard inline or in a small popover-style panel, depending on available space.
+- The keyboard displays a selectable range of notes relevant to the current instrument and octave context.
+- Keys can be clicked with the mouse or touch input to preview a note.
+- Mapped computer keys trigger the same preview notes.
+- MIDI keyboard input, when enabled, triggers the same preview notes.
+- The active key is highlighted whenever a note is triggered from any supported input path.
+- Scale awareness can optionally influence key styling so the user can see in-scale vs out-of-scale notes.
+
+### Interaction model
+
+| Input | Behavior |
+|---|---|
+| Keyboard icon click | Toggle the virtual keyboard open/closed |
+| Virtual key click/tap | Preview the corresponding note |
+| Computer-keyboard shortcut | Preview the mapped note and highlight the key |
+| MIDI keyboard input | Preview the corresponding note and highlight the key |
+| Active preview ends | Remove highlight after note-off / preview timeout |
+
+### Visual states
+
+- **Idle**: keyboard visible, no note highlighted.
+- **Active preview**: the triggered key is highlighted with the channel or instrument accent.
+- **Scale-aware**: in-scale keys use the active scale styling; out-of-scale keys are visually distinct but still available unless the scale feature explicitly disables them.
+- **Unavailable input**: if MIDI is disabled or unavailable, the virtual keyboard still works with mouse and mapped computer keys.
+
+### Layout guidance
+
+- Keep the keyboard compact enough to fit above or near the instrument controls in the Web UI.
+- Prefer a responsive layout that can collapse or scroll horizontally on narrow screens.
+- Preserve the existing instrument workflow; the keyboard should augment note preview rather than replace editing controls.
+
+---
+
+## Keyboard Mapping
+
+The Web UI should maintain a stable mapping between physical keyboard input and musical notes.
+
+### Requirements
+
+- The mapping must be deterministic and visible in the UI, either through tooltips, labels, or an accessible help hint.
+- White and black keys should each map to a corresponding note in the selected preview range.
+- The mapping should be easy to extend if the application later supports alternate layouts or octave shifting.
+- The mapping should not require the user to enable the virtual keyboard to use computer-keyboard preview.
+
+### Suggested behaviors
+
+- Default mapping follows the current note-preview range.
+- If the preview range spans multiple octaves, the mapping should preserve relative pitch order.
+- If the scale-awareness feature is enabled, mapped notes should still trigger even when they are outside the active scale, but they should be styled distinctly if that is the chosen UI policy.
+
+---
+
+## MIDI Integration
+
+If MIDI keyboard preview is enabled, incoming MIDI note-on and note-off messages should drive the same highlight and preview path as mouse and computer-keyboard input.
+
+### Requirements
+
+- MIDI input must map to the same note identity used by the virtual keyboard.
+- The highlighted key must update immediately on MIDI note-on.
+- The highlight must clear on MIDI note-off or equivalent timeout behavior.
+- MIDI preview should be optional and respect the user’s existing MIDI enablement settings.
+
+---
+
+## Scale Awareness Integration
+
+This feature is expected to work alongside [`scale-awareness.md`](complete/scale-awareness.md).
+
+### Intended relationship
+
+- The virtual keyboard can display scale membership for the current song scale.
+- In-scale notes can be emphasized, while out-of-scale notes can be dimmed or marked.
+- The keyboard should reflect scale changes without requiring a page reload.
+- Previewing a note should still work regardless of scale styling, unless a separate enforcement rule explicitly blocks it.
+
+### Suggested UI signals
+
+- Active scale root and mode may be shown in a compact label above the keyboard.
+- In-scale notes can use a stronger accent or filled key style.
+- Out-of-scale notes can remain selectable but subdued.
+
+---
+
+## Implementation Plan
+
+### Web UI Changes
+
+- Replace the static note-label preview strip with a keyboard icon and expandable keyboard panel.
+- Add a virtual keyboard component that renders note keys and handles click/tap input.
+- Wire preview note events from mouse, computer keyboard, and MIDI input into one shared highlight path.
+- Add keyboard state to the relevant Web UI store or panel state.
+- Integrate optional scale-aware key styling using the existing scale-awareness data.
+
+### Accessibility
+
+- The keyboard icon must have an accessible name and keyboard activation support.
+- Keys must be reachable by keyboard and expose a clear role or equivalent semantic structure.
+- The currently active note should be announced in a way that works for assistive technology.
+- Color alone must not be the only indicator of scale membership or active preview.
+
+### Data / State
+
+- Track the currently previewed note identity, source input type, and active range.
+- Track whether the keyboard panel is open or collapsed.
+- Reuse existing MIDI enablement state rather than creating a separate MIDI preference model.
+
+### Documentation Updates
+
+- Add a user-facing explanation of the keyboard icon and input mappings in the web-ui docs.
+- Update any tutorial or feature overview content that still references static note labels as the primary preview mechanism.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Toggling the keyboard icon opens and closes the virtual keyboard.
+- Clicking a virtual key emits the correct preview note.
+- Computer-keyboard input maps to the expected note.
+- MIDI note events resolve to the same key highlight as UI input.
+- Scale-aware styling reflects in-scale and out-of-scale state correctly.
+
+### Integration Tests
+
+- The Web UI renders the keyboard icon in place of the old static preview labels.
+- Preview highlight updates correctly when notes are triggered from different input paths.
+- The keyboard stays usable on narrow screens.
+- The component works with the scale-awareness state when that feature is enabled.
+
+---
+
+## Migration Path
+
+- Keep the current note preview behavior available until the virtual keyboard is ready to replace it.
+- Ship the keyboard icon and expanded view as a non-breaking UI change.
+- Preserve existing preview note triggering so current workflows continue to work.
+
+---
+
+## Implementation Checklist
+
+- [ ] Replace static note-label preview with a keyboard icon entry point.
+- [ ] Implement an expandable virtual keyboard component.
+- [ ] Wire mouse/touch preview handling.
+- [ ] Wire computer-keyboard preview handling.
+- [ ] Wire MIDI preview handling when MIDI is enabled.
+- [ ] Highlight the active key for all preview sources.
+- [ ] Add optional scale-aware styling and state sync.
+- [ ] Add accessibility semantics and keyboard support.
+- [ ] Add unit and integration tests.
+- [ ] Update Web UI documentation and tutorials.
+
+---
+
+## Future Enhancements
+
+- Octave shift controls for the preview range.
+- Alternate keyboard layouts for different play styles.
+- Chord preview and chord highlighting.
+- Persistent user preference for compact vs expanded keyboard display.
+- Note-range zoom for instruments with wider preview spans.
+
+---
+
+## Open Questions
+
+1. Should the virtual keyboard open inline or in a popover by default?
+2. Should out-of-scale notes be selectable but dimmed, or disabled when scale awareness is active?
+3. Should the keyboard remember the last opened state per session or per user preference?
+4. Should computer-keyboard mappings be shown directly on the key caps or in a legend above the keyboard?
+
+---
+
+## References
+
+- Scale awareness: [`docs/features/complete/scale-awareness.md`](complete/scale-awareness.md)
+- Web UI docs: [`docs/ui/`](../ui/)
+- MIDI importer: [`docs/features/midi-importer.md`](midi-importer.md)
+- Existing Web UI preview area: instrument and note preview controls in the web-ui panel
+
+---
+
+## Additional Notes
+
+This feature is intentionally focused on preview and auditioning, not on changing song structure or replacing the editor’s note-entry model. The goal is to make note discovery and auditioning feel like playing an instrument while preserving the existing BeatBax workflow.

--- a/packages/cli/tests/verify-mixed-errors.integration.test.ts
+++ b/packages/cli/tests/verify-mixed-errors.integration.test.ts
@@ -20,7 +20,7 @@ describe('CLI verify mixed syntax + semantic errors', () => {
 
   it('reports syntax recovery errors and semantic diagnostics together', () => {
     writeFileSync(TEST_SONG_PATH, [
-      'chip ned',
+      'chip nes',
       'song tgs "a,b"',
       'inst bass type=dxm dury=50 made_up=1',
       'pat melody = C5 JEFF G5',
@@ -38,9 +38,7 @@ describe('CLI verify mixed syntax + semantic errors', () => {
     }
 
     expect(output).toContain("Unknown keyword 'saq'");
-    expect(output).toContain("Unknown chip 'ned'");
-    expect(output).toContain("Instrument 'bass': unknown type 'dxm'");
-    expect(output).toContain("unknown property 'dury'");
+    expect(output).toContain("Unknown NES instrument type 'dxm'");
     expect(output).toContain("unknown token 'JEFF'");
   });
 });

--- a/packages/engine/src/chips/nes/ui-contributions.ts
+++ b/packages/engine/src/chips/nes/ui-contributions.ts
@@ -91,6 +91,47 @@ const hoverDocs: Record<string, string> = {
     'Example: `inst kick type=noise noise_mode=normal noise_period=12 env=15,down env_period=3`',
   ].join('\n\n'),
 
+  type: [
+    '**Channel type** — selects which NES APU voice this instrument drives.',
+    '```\ntype=<pulse1|pulse2|triangle|noise|dmc>\n```',
+    '- `pulse1` — square wave, channel 1; supports `duty`, `env`, hardware sweep',
+    '- `pulse2` — square wave, channel 2; same as pulse1 but on channel 2',
+    '- `triangle` — fixed 32-step triangle, channel 3; no hardware volume envelope',
+    '- `noise` — LFSR percussion, channel 4; tune with `noise_period` and `env`',
+    '- `dmc` — delta sample playback, channel 5; set `dmc_sample` and `dmc_rate`',
+    '',
+    'Hover a type value (e.g. `pulse1`) for channel-specific documentation.',
+    '',
+    'Example: `inst lead type=pulse1 duty=25 env=13,down env_period=2`',
+  ].join('\n\n'),
+
+  duty: [
+    '**Duty cycle** — pulse width for NES square-wave channels (`pulse1` and `pulse2`).',
+    '```\nduty=<value>\n```',
+    '- `12` / `12.5` — thin, bright, cutting (leads, arpeggios)',
+    '- `25` — classic hollow square timbre',
+    '- `50` — balanced, full-sounding (common default)',
+    '- `75` — darker, thicker tone (phase-inverted 25%)',
+    '',
+    'Hover a value like `duty=50` to see the selected width.',
+    '',
+    'Example: `inst lead type=pulse1 duty=25 env=13,down`',
+  ].join('\n\n'),
+
+  vol: [
+    '**Constant volume** — fixed amplitude **0–15** for the note (bypasses envelope decay).',
+    '```\nvol=<0-15>\n```',
+    '- Use instead of `env=` when you want a steady level for the whole note',
+    '- `0` mutes the channel (software gate; useful on triangle for rhythmic cuts)',
+    '- When `vol_env=[…]` is set, the macro overrides `vol` at playback time',
+    '',
+    '_Triangle channel: hardware level is always maximum; only `vol=0` silences._',
+    '',
+    'Hover a value like `vol=10` for level details.',
+    '',
+    'Example: `inst lead type=pulse1 duty=50 vol=10`',
+  ].join('\n\n'),
+
   pulse1: [
     '**Pulse 1** — NES APU square-wave oscillator (channel 1).',
     'Supports duty cycle, envelope, constant volume, and hardware frequency sweep.',

--- a/packages/engine/src/parser/peggy/index.ts
+++ b/packages/engine/src/parser/peggy/index.ts
@@ -980,7 +980,8 @@ export function parseWithPeggy(source: string): ParseResult {
   const requestedChip = String(chipName || '').toLowerCase();
   const canonicalChip = requestedChip ? chipRegistry.resolve(requestedChip) : '';
   const registeredChips = chipRegistry.list();
-  if (chipName && !registeredChips.includes(requestedChip)) {
+  const chipIsKnown = !chipName || chipRegistry.has(requestedChip);
+  if (chipName && !chipIsKnown) {
     diag('error', 'parser', `Unknown chip '${chipName}'. Supported chips: ${registeredChips.join(', ')}.`, chipLoc);
   }
   if (chipRegion) {
@@ -1007,7 +1008,9 @@ export function parseWithPeggy(source: string): ParseResult {
   // When the song targets a registered chip plugin, delegate to its validateInstrument()
   // so the plugin can accept its own types (e.g. 'triangle', 'dmc' for NES) and
   // known properties (e.g. sweep_en, noise_period) without false warnings.
-  const activePlugin = chipName ? chipRegistry.get(String(chipName).toLowerCase()) : undefined;
+  // Skip entirely when `chip` is unknown — otherwise we fall back to Game Boy rules and
+  // flood the editor with misleading instrument errors (e.g. NES triangle → unknown type).
+  const activePlugin = chipIsKnown && chipName ? chipRegistry.get(requestedChip) : undefined;
 
   const VALID_INST_TYPES = ['pulse1', 'pulse2', 'wave', 'noise'];
   const INST_COMMON_PROPS = new Set(['type', 'volume', 'length', 'gm', 'note', 'env', 'envelope', 'speed', 'pan']);
@@ -1017,7 +1020,7 @@ export function parseWithPeggy(source: string): ParseResult {
     wave:   new Set(['wave']),
     noise:  new Set(['width', 'divisor', 'shift', 'lfsr']),
   };
-  for (const [instName, instDef] of Object.entries(insts)) {
+  if (chipIsKnown) for (const [instName, instDef] of Object.entries(insts)) {
     const p = instDef as any;
     const instLoc: SourceLocation | undefined = p.__loc;
     const type: string | undefined = p.type;

--- a/packages/engine/tests/chip-directive.test.ts
+++ b/packages/engine/tests/chip-directive.test.ts
@@ -65,4 +65,17 @@ describe('chip directive', () => {
     const messages = (result.ast.diagnostics || []).map(d => d.message);
     expect(messages.some(m => m.includes("only supported for 'chip sms', 'chip nes', and 'chip famicom'"))).toBe(true);
   });
+
+  test('unknown chip does not cascade into Game Boy instrument validation', () => {
+    const src = [
+      'chip nesx',
+      'inst bass type=triangle linear=true',
+      'inst hihat type=noise noise_mode=periodic noise_period=8 env_period=1',
+    ].join('\n');
+    const result = parseWithPeggy(src);
+    const messages = (result.ast.diagnostics || []).map(d => d.message);
+    expect(messages.some(m => m.includes("Unknown chip 'nesx'"))).toBe(true);
+    expect(messages.some(m => m.includes('unknown type'))).toBe(false);
+    expect(messages.some(m => m.includes('unknown property'))).toBe(false);
+  });
 });

--- a/packages/plugins/chip-sms/src/ui-contributions.ts
+++ b/packages/plugins/chip-sms/src/ui-contributions.ts
@@ -101,6 +101,34 @@ const hoverDocs: Record<string, string> = {
     'Example: `inst lead type=tone1 vol=10 vol_env=[0,3,6,9,12,15]`',
   ].join('\n\n'),
 
+  type: [
+    '**Channel type** — selects which SN76489 voice this instrument drives.',
+    '```\ntype=<tone1|tone2|tone3|noise>\n```',
+    '- `tone1` — square wave, channel 1; `vol`, `vol_env`, `arp_env`, `pitch_env`',
+    '- `tone2` — square wave, channel 2; same fields as tone1',
+    '- `tone3` — square wave, channel 3; can sync noise via `noise_rate=tone3`',
+    '- `noise` — LFSR percussion, channel 4; `noise_mode`, `noise_rate`, `vol`, `vol_env`',
+    '',
+    'Hover a type value (e.g. `tone1`) for channel-specific documentation.',
+    '',
+    'Example: `inst lead type=tone1 vol=10 vol_env=[0,3,6,9,12,15]`',
+  ].join('\n\n'),
+
+  vol: [
+    '**Constant volume** — fixed attenuation level **0–15** for the note.',
+    '```\nvol=<0-15>\n```',
+    'SMS uses **attenuation** semantics (opposite of NES):',
+    '- **`0` = loudest** (minimum attenuation, full level)',
+    '- **`15` = silent** (maximum attenuation, mute)',
+    '',
+    'Use `vol_env=[…]` for shaped dynamics; the macro overrides a static `vol` at playback.',
+    'On Game Gear, combine with `gg:pan=L|C|R` for stereo placement.',
+    '',
+    'Hover a value like `vol=10` for level details.',
+    '',
+    'Example: `inst lead type=tone1 vol=10`',
+  ].join('\n\n'),
+
   sms: [
     '**Sega Master System (SMS)** — SN76489 PSG sound chip.',
     '',

--- a/packages/plugins/chip-spectrum-128/src/ui-contributions.ts
+++ b/packages/plugins/chip-spectrum-128/src/ui-contributions.ts
@@ -116,6 +116,40 @@ const hoverDocs: Record<string, string> = {
     'the shared hardware envelope, combine fixed `vol` with `volSlide` on pattern notes.',
   ].join('\n'),
 
+  type: [
+    '**Channel type** — selects which AY-3-8912 tone/noise voice this instrument drives.',
+    '```\ntype=<tone1|tone2|tone3>\n```',
+    '- `tone1` — square wave, AY channel A (BeatBax channel 1)',
+    '- `tone2` — square wave, AY channel B (BeatBax channel 2)',
+    '- `tone3` — square wave, AY channel C (BeatBax channel 3)',
+    '',
+    'All tone channels output a fixed 50% duty square wave. Percussion uses `tone_mix=true`',
+    'to blend the shared noise generator into a tone channel.',
+    '',
+    'Hover a type value (e.g. `tone1`) for channel-specific documentation.',
+    '',
+    'Example: `inst lead type=tone1 vol=12 arp_env=[0,4,7|0]`',
+  ].join('\n'),
+
+  tone1: [
+    '**Tone 1** — AY-3-8912 square-wave channel A (BeatBax channel 1).',
+    'Fixed 50% duty. No hardware duty or sweep.',
+    '```\ninst lead type=tone1 vol=12 arp_env=[0,4,7|0] pitch_env=[0,-2,0]\n```',
+    'Supported fields: `vol`, `vol_env`, `arp_env`, `pitch_env`, `tone`, `tone_mix`, `noise_rate`, …',
+  ].join('\n'),
+
+  tone2: [
+    '**Tone 2** — AY-3-8912 square-wave channel B (BeatBax channel 2).',
+    'Same capabilities as tone1.',
+    '```\ninst harm type=tone2 vol=10 pitch_env=[0,2,0,-2,0]\n```',
+  ].join('\n'),
+
+  tone3: [
+    '**Tone 3** — AY-3-8912 square-wave channel C (BeatBax channel 3).',
+    'Same capabilities as tone1/tone2. Commonly used for bass and multiplexed percussion.',
+    '```\ninst bass type=tone3 vol=14\ninst kick type=tone3 tone_mix=true noise_rate=4 note=C3\n```',
+  ].join('\n'),
+
   tone: [
     '**tone** — Force the tone generator on or off (R7 mixer bit).',
     '',


### PR DESCRIPTION
<!-- Describe the purpose of this PR and the changes it makes. -->

### Summary

Add chip-aware inst-line hovers (gm, note, type, vol, vol_env), MIDI note preview without arming Record, persistent fold-comments, and View menu/toolbar improvements for wrap and fold toggles.

### Checklist

- [X] My changes add required tests and they pass.
- [X] I ran `npm test` locally and all tests passed.
- [X] I updated README or docs if required.
- [X] This PR follows repository coding style and guidelines.

### Notes for reviewers

None
