### PR TITLE
fix(desktop): allow spaces in Default song artist setting

### DIFF
--- a/apps/desktop/src/renderer/src/components/settings/editor.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/editor.tsx
@@ -149,7 +149,12 @@ export function EditorSettingsSection(): React.JSX.Element {
       <NoteText>Beat decorations tint note tokens inside pat blocks: downbeats are highlighted more strongly, upbeats more subtly, making the rhythmic structure visible while editing.</NoteText>
 
       <NumberField label="Default BPM" max={300} min={60} onChange={(value) => settingDefaultBpm.set(value)} value={defaultBpm} />
-      <TextField label="Default song artist" onChange={(value) => settingSongArtist.set(value.trim())} value={songArtist} />
+      <TextField
+        label="Default song artist"
+        onBlur={commitDefaultSongArtist}
+        onChange={applyDefaultSongArtistDraft}
+        value={songArtist}
+      />
       <NumberField
         label="Font size"
         max={24}
@@ -309,6 +314,20 @@ export function EditorSettingsSection(): React.JSX.Element {
       </div>
     </div>
   );
+}
+
+/**
+ * Persist Default song artist while the controlled text field is being edited.
+ * Must not trim: trimming on every keystroke strips trailing spaces and blocks
+ * multi-word names such as "The BeatBax Team".
+ */
+export function applyDefaultSongArtistDraft(value: string): void {
+  settingSongArtist.set(value);
+}
+
+/** Normalize leading/trailing whitespace when the Default song artist field blurs. */
+export function commitDefaultSongArtist(value: string): void {
+  settingSongArtist.set(value.trim());
 }
 
 export function resetEditorDefaults(): void {

--- a/apps/desktop/src/renderer/src/components/settings/form.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/form.tsx
@@ -160,12 +160,14 @@ export function TextField({
   id,
   inputType = 'text',
   label,
+  onBlur,
   onChange,
   value,
 }: {
   id?: string;
   inputType?: string;
   label: string;
+  onBlur?: (value: string) => void;
   onChange: (value: string) => void;
   value: string;
 }): React.JSX.Element {
@@ -176,6 +178,7 @@ export function TextField({
       <input
         className="bb-settings-text"
         id={fieldId}
+        onBlur={(event) => onBlur?.(event.currentTarget.value)}
         onChange={(event) => onChange(event.currentTarget.value)}
         type={inputType}
         value={value}

--- a/apps/desktop/src/renderer/src/lib/desktop-workspace.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-workspace.ts
@@ -441,7 +441,7 @@ export function createDesktopWorkspace(options: DesktopWorkspaceOptions): Deskto
         return plugin ? [{ id, plugin }] : [];
       }),
       getDefaultBpm: () => settingDefaultBpm.get(),
-      getDefaultArtist: () => settingSongArtist.get(),
+      getDefaultArtist: () => settingSongArtist.get().trim(),
       onPreview: (source, { onEnded }) => {
         const unsub = eventBus.on('playback:stopped', () => {
           unsub();

--- a/apps/desktop/tests/default-song-artist.test.ts
+++ b/apps/desktop/tests/default-song-artist.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression: Default song artist must accept multi-word values with spaces.
+ *
+ * The desktop settings field is a controlled React input backed by nanostores.
+ * Trimming on every onChange strips trailing spaces mid-edit, which makes it
+ * impossible to type names like "The BeatBax Team". Draft updates must keep
+ * internal/trailing spaces; commit (blur) may normalize ends.
+ */
+
+import { settingSongArtist } from '@beatbax/app-core/stores/settings.store';
+import {
+  applyDefaultSongArtistDraft,
+  commitDefaultSongArtist,
+} from '../src/renderer/src/components/settings/editor';
+
+beforeEach(() => {
+  localStorage.clear();
+  settingSongArtist.set('');
+});
+
+describe('Default song artist setting', () => {
+  it('preserves spaces while drafting (no per-keystroke trim)', () => {
+    applyDefaultSongArtistDraft('The');
+    expect(settingSongArtist.get()).toBe('The');
+
+    applyDefaultSongArtistDraft('The ');
+    expect(settingSongArtist.get()).toBe('The ');
+
+    applyDefaultSongArtistDraft('The BeatBax Team');
+    expect(settingSongArtist.get()).toBe('The BeatBax Team');
+  });
+
+  it('trims only on commit (blur)', () => {
+    applyDefaultSongArtistDraft('  The BeatBax Team  ');
+    expect(settingSongArtist.get()).toBe('  The BeatBax Team  ');
+
+    commitDefaultSongArtist(settingSongArtist.get());
+    expect(settingSongArtist.get()).toBe('The BeatBax Team');
+  });
+
+  it('does not remove internal spaces when committing', () => {
+    applyDefaultSongArtistDraft('The BeatBax Team');
+    commitDefaultSongArtist(settingSongArtist.get());
+    expect(settingSongArtist.get()).toBe('The BeatBax Team');
+  });
+});

--- a/apps/web-ui/tests/new-song-wizard.test.ts
+++ b/apps/web-ui/tests/new-song-wizard.test.ts
@@ -286,7 +286,7 @@ describe('New Song Wizard', () => {
     expect(backdrop.classList.contains('bb-new-song-wizard-backdrop--open')).toBe(false);
   });
 
-  it('quotes multi-word default artists with spaces in generated song source', () => {
+  it('quotes a multi-word default artist with spaces in generated song source', () => {
     const onCreate = jest.fn();
     const wizard = buildNewSongWizard({
       getEnabledChips: () => [{ id: 'nes', plugin: makeChip('nes') }],

--- a/apps/web-ui/tests/new-song-wizard.test.ts
+++ b/apps/web-ui/tests/new-song-wizard.test.ts
@@ -285,6 +285,26 @@ describe('New Song Wizard', () => {
     getWizardElements().cancelBtn().click();
     expect(backdrop.classList.contains('bb-new-song-wizard-backdrop--open')).toBe(false);
   });
+
+  it('quotes multi-word default artists with spaces in generated song source', () => {
+    const onCreate = jest.fn();
+    const wizard = buildNewSongWizard({
+      getEnabledChips: () => [{ id: 'nes', plugin: makeChip('nes') }],
+      getDefaultBpm: () => 120,
+      getDefaultArtist: () => 'The BeatBax Team',
+      onCreate,
+    });
+    wizard.open();
+    const el = getWizardElements();
+    expect(el.artist().value).toBe('The BeatBax Team');
+    el.songName().value = 'Spaces Song';
+    const [, effectsToggle] = el.exampleToggles();
+    effectsToggle.checked = false;
+    el.createBtn().click();
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const payload = onCreate.mock.calls[0][0];
+    expect(payload.source).toContain('song artist "The BeatBax Team"');
+  });
 });
 
 describe('claimNewSongWizardOnboarding', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The desktop **Default song artist** setting (Settings → Editor) used a controlled React input that called `.trim()` on every keystroke. That stripped trailing spaces mid-edit, so multi-word names like `The BeatBax Team` could not be typed.

## Changes
- Persist the artist value as typed while editing; trim leading/trailing whitespace only on blur
- Add optional `onBlur` support to the shared settings `TextField`
- Trim when applying the default artist in the New Song Wizard
- Add regression tests for draft/commit behavior and multi-word artist quoting in generated song source

## Test plan
- [x] Unit: `@beatbax/desktop` `default-song-artist` (3 passed)
- [x] Unit: `@beatbax/web-ui` `new-song-wizard` including multi-word artist quoting (9 passed)
- [ ] Open desktop Settings → Editor → Default song artist
- [ ] Type `The BeatBax Team` (spaces between words) and confirm it sticks
- [ ] Create a new song and confirm `song artist "The BeatBax Team"` appears in the generated source

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc943-7266-7717-805d-99ecaec40052?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc943-7266-7717-805d-99ecaec40052&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

