### PR TITLE
Fix toolbar click/hover reliability and add Settings shortcut.

### DIFF
--- a/apps/desktop/src/renderer/src/components/panels/DesktopCopilotPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/panels/DesktopCopilotPanel.tsx
@@ -1034,6 +1034,7 @@ function DesktopCopilotPanel({
         <div className="bb-chat-title-row">
           <span className="bb-chat-title" dangerouslySetInnerHTML={{ __html: `${icon('sparkles', 'w-4 h-4 inline-block mr-1')}BeatBax Copilot` }} />
           <button
+            aria-label="Open AI settings"
             className="bb-chat-settings-btn"
             dangerouslySetInnerHTML={{ __html: icon('cog-6-tooth', 'w-4 h-4') }}
             onClick={onOpenSettings}

--- a/apps/desktop/src/renderer/src/components/panels/DesktopSongVisualizer.tsx
+++ b/apps/desktop/src/renderer/src/components/panels/DesktopSongVisualizer.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
   type Ref,
 } from 'react';
 import { flushSync } from 'react-dom';
@@ -477,6 +478,13 @@ function DesktopSongVisualizer({
     });
   }, [syncChannelInfoFromStore]);
 
+  const handleToolbarAction = useCallback((event: ReactPointerEvent<HTMLButtonElement>, disabled: boolean, action: () => void) => {
+    if (event.button !== 0 || disabled) return;
+    event.preventDefault();
+    event.stopPropagation();
+    action();
+  }, []);
+
   const resetAllChannels = useCallback(() => {
     setPositions({});
     clearLevels();
@@ -693,6 +701,8 @@ function DesktopSongVisualizer({
     : fullscreenActive
       ? 'arrows-pointing-in'
       : 'arrows-pointing-out';
+  const anyMuted = Object.values(channelInfo).some((state) => state.muted);
+  const anySoloed = Object.values(channelInfo).some((state) => state.soloed);
 
   return (
     <div
@@ -714,20 +724,24 @@ function DesktopSongVisualizer({
         onPointerLeave={performanceMode ? unpinChrome : undefined}
       >
         <button
+          aria-disabled={!anyMuted ? 'true' : undefined}
+          aria-label="Unmute all channels"
           className="bb-viz__toolbar-btn"
-          disabled={!Object.values(channelInfo).some((state) => state.muted)}
           dangerouslySetInnerHTML={{ __html: icon('speaker-wave') }}
+          data-aria-disabled={!anyMuted ? 'true' : undefined}
           id="bb-viz-unmute-all"
-          onClick={() => runChannelStateAction(unmuteAll)}
+          onPointerDown={(event) => handleToolbarAction(event, !anyMuted, () => runChannelStateAction(unmuteAll))}
           title="Unmute all channels"
           type="button"
         />
         <button
+          aria-disabled={!anySoloed ? 'true' : undefined}
+          aria-label="Clear solo on all channels"
           className="bb-viz__toolbar-btn"
-          disabled={!Object.values(channelInfo).some((state) => state.soloed)}
           dangerouslySetInnerHTML={{ __html: icon('eye') }}
+          data-aria-disabled={!anySoloed ? 'true' : undefined}
           id="bb-viz-clear-solo"
-          onClick={() => runChannelStateAction(clearAllSolo)}
+          onPointerDown={(event) => handleToolbarAction(event, !anySoloed, () => runChannelStateAction(clearAllSolo))}
           title="Clear solo"
           type="button"
         />
@@ -758,7 +772,7 @@ function DesktopSongVisualizer({
           className="bb-viz__toolbar-btn bb-viz__toolbar-btn--performance"
           dangerouslySetInnerHTML={{ __html: icon(performanceIcon) }}
           id="bb-viz-fullscreen"
-          onClick={() => {
+          onPointerDown={(event) => handleToolbarAction(event, false, () => {
             if (!performanceMode) {
               flushSync(() => setPerformanceMode(true));
               return;
@@ -768,7 +782,7 @@ function DesktopSongVisualizer({
               return;
             }
             void rootRef.current?.requestFullscreen?.().catch(() => undefined);
-          }}
+          })}
           title={performanceTitle}
           type="button"
         />
@@ -778,10 +792,10 @@ function DesktopSongVisualizer({
             className="bb-viz__toolbar-btn bb-viz__toolbar-btn--exit-performance"
             dangerouslySetInnerHTML={{ __html: icon('x-mark') }}
             id="bb-viz-exit"
-            onClick={() => {
+            onPointerDown={(event) => handleToolbarAction(event, false, () => {
               flushSync(() => setPerformanceMode(false));
               if (document.fullscreenElement) void document.exitFullscreen?.().catch(() => undefined);
-            }}
+            })}
             title="Exit performance mode"
             type="button"
           />
@@ -830,6 +844,7 @@ function DesktopSongVisualizer({
                   </div>
                   <div className="bb-viz__ctrl-row">
                     <button
+                      aria-label={muted ? 'Unmute channel' : 'Mute channel'}
                       aria-pressed={muted}
                       className={`bb-cp__btn bb-cp__btn--mute${muted ? ' bb-cp__btn--active' : ''}`}
                       id={`bb-viz-mute-${ch.id}`}
@@ -844,6 +859,7 @@ function DesktopSongVisualizer({
                       M
                     </button>
                     <button
+                      aria-label={soloed ? 'Unsolo channel' : 'Solo channel'}
                       aria-pressed={soloed}
                       className={`bb-cp__btn bb-cp__btn--solo${soloed ? ' bb-cp__btn--active' : ''}`}
                       id={`bb-viz-solo-${ch.id}`}
@@ -852,7 +868,7 @@ function DesktopSongVisualizer({
                       onFocus={performanceMode ? pinChrome : undefined}
                       onPointerEnter={performanceMode ? pinChrome : undefined}
                       onPointerLeave={performanceMode ? unpinChrome : undefined}
-                      title={soloed ? 'Remove solo' : 'Solo this channel'}
+                      title={soloed ? 'Unsolo channel' : 'Solo channel'}
                       type="button"
                     >
                       S

--- a/apps/desktop/src/renderer/src/components/panels/DesktopSongVisualizer.tsx
+++ b/apps/desktop/src/renderer/src/components/panels/DesktopSongVisualizer.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type Ref,
 } from 'react';
@@ -485,6 +486,34 @@ function DesktopSongVisualizer({
     action();
   }, []);
 
+  /** Enter/Space activate via click with detail === 0 (no preceding pointerdown). */
+  const handleToolbarKeyboardClick = useCallback((event: ReactMouseEvent<HTMLButtonElement>, disabled: boolean, action: () => void) => {
+    if (event.detail !== 0 || disabled) return;
+    event.preventDefault();
+    event.stopPropagation();
+    action();
+  }, []);
+
+  const unmuteAllChannels = useCallback(() => runChannelStateAction(unmuteAll), [runChannelStateAction]);
+  const clearSoloChannels = useCallback(() => runChannelStateAction(clearAllSolo), [runChannelStateAction]);
+
+  const togglePerformanceOrFullscreen = useCallback(() => {
+    if (!performanceMode) {
+      flushSync(() => setPerformanceMode(true));
+      return;
+    }
+    if (document.fullscreenElement) {
+      void document.exitFullscreen?.().catch(() => undefined);
+      return;
+    }
+    void rootRef.current?.requestFullscreen?.().catch(() => undefined);
+  }, [performanceMode]);
+
+  const exitPerformanceMode = useCallback(() => {
+    flushSync(() => setPerformanceMode(false));
+    if (document.fullscreenElement) void document.exitFullscreen?.().catch(() => undefined);
+  }, []);
+
   const resetAllChannels = useCallback(() => {
     setPositions({});
     clearLevels();
@@ -730,7 +759,8 @@ function DesktopSongVisualizer({
           dangerouslySetInnerHTML={{ __html: icon('speaker-wave') }}
           data-aria-disabled={!anyMuted ? 'true' : undefined}
           id="bb-viz-unmute-all"
-          onPointerDown={(event) => handleToolbarAction(event, !anyMuted, () => runChannelStateAction(unmuteAll))}
+          onClick={(event) => handleToolbarKeyboardClick(event, !anyMuted, unmuteAllChannels)}
+          onPointerDown={(event) => handleToolbarAction(event, !anyMuted, unmuteAllChannels)}
           title="Unmute all channels"
           type="button"
         />
@@ -741,7 +771,8 @@ function DesktopSongVisualizer({
           dangerouslySetInnerHTML={{ __html: icon('eye') }}
           data-aria-disabled={!anySoloed ? 'true' : undefined}
           id="bb-viz-clear-solo"
-          onPointerDown={(event) => handleToolbarAction(event, !anySoloed, () => runChannelStateAction(clearAllSolo))}
+          onClick={(event) => handleToolbarKeyboardClick(event, !anySoloed, clearSoloChannels)}
+          onPointerDown={(event) => handleToolbarAction(event, !anySoloed, clearSoloChannels)}
           title="Clear solo"
           type="button"
         />
@@ -772,17 +803,8 @@ function DesktopSongVisualizer({
           className="bb-viz__toolbar-btn bb-viz__toolbar-btn--performance"
           dangerouslySetInnerHTML={{ __html: icon(performanceIcon) }}
           id="bb-viz-fullscreen"
-          onPointerDown={(event) => handleToolbarAction(event, false, () => {
-            if (!performanceMode) {
-              flushSync(() => setPerformanceMode(true));
-              return;
-            }
-            if (document.fullscreenElement) {
-              void document.exitFullscreen?.().catch(() => undefined);
-              return;
-            }
-            void rootRef.current?.requestFullscreen?.().catch(() => undefined);
-          })}
+          onClick={(event) => handleToolbarKeyboardClick(event, false, togglePerformanceOrFullscreen)}
+          onPointerDown={(event) => handleToolbarAction(event, false, togglePerformanceOrFullscreen)}
           title={performanceTitle}
           type="button"
         />
@@ -792,10 +814,8 @@ function DesktopSongVisualizer({
             className="bb-viz__toolbar-btn bb-viz__toolbar-btn--exit-performance"
             dangerouslySetInnerHTML={{ __html: icon('x-mark') }}
             id="bb-viz-exit"
-            onPointerDown={(event) => handleToolbarAction(event, false, () => {
-              flushSync(() => setPerformanceMode(false));
-              if (document.fullscreenElement) void document.exitFullscreen?.().catch(() => undefined);
-            })}
+            onClick={(event) => handleToolbarKeyboardClick(event, false, exitPerformanceMode)}
+            onPointerDown={(event) => handleToolbarAction(event, false, exitPerformanceMode)}
             title="Exit performance mode"
             type="button"
           />

--- a/apps/desktop/src/renderer/src/components/workspace/DesktopToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/workspace/DesktopToolbar.tsx
@@ -47,6 +47,7 @@ export interface DesktopToolbarOptions {
   onUndo?: () => void;
   onRedo?: () => void;
   onToggleTheme?: () => void;
+  onOpenSettings?: () => void;
   onToggleWrap?: (enabled: boolean) => void;
   onToggleFoldComments?: () => void;
 }
@@ -94,6 +95,7 @@ function DesktopToolbar({
   onSave,
   onToggleFoldComments,
   onToggleTheme,
+  onOpenSettings,
   onToggleWrap,
   onUndo,
   onVerify,
@@ -277,6 +279,19 @@ function DesktopToolbar({
           <ToolbarIcon name={theme === 'dark' ? 'sun' : 'moon'} />
           <span className="bb-toolbar__btn-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
         </button>
+        {caps.settingsPanel ? (
+          <button
+            aria-label={`Settings (${toolbarShortcut('tools.openSettings')})`}
+            className="bb-toolbar__btn bb-toolbar__btn--icon"
+            id="tb-settings"
+            onClick={() => onOpenSettings?.()}
+            title={`Settings (${toolbarShortcut('tools.openSettings')})`}
+            type="button"
+          >
+            <ToolbarIcon name="cog-6-tooth" />
+            <span className="bb-toolbar__btn-label">Settings</span>
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/lib/desktop-workspace.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-workspace.ts
@@ -503,6 +503,7 @@ export function createDesktopWorkspace(options: DesktopWorkspaceOptions): Deskto
     onUndo: () => getEditor()?.editor.trigger('toolbar', 'undo', null),
     onRedo: () => getEditor()?.editor.trigger('toolbar', 'redo', null),
     onToggleTheme: () => themeManager.toggle(),
+    onOpenSettings: () => settingsModal.open(),
     onToggleWrap: (wrap) => viewPrefsHandlers?.onToggleWrap(wrap),
     onToggleFoldComments: () => viewPrefsHandlers?.onToggleFoldComments(),
   });

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -140,6 +140,13 @@ code {
   min-width: 0;
 }
 
+/* Performance mode overlays the title bar; Electron drag regions steal clicks
+   through higher-z overlays, so disable drag while the visualizer owns the viewport. */
+body.bb-viz-wide-mode .desktop-title-bar,
+body.bb-viz-wide-mode .desktop-title-bar__drag {
+  -webkit-app-region: no-drag;
+}
+
 .desktop-title-bar__controls {
   display: flex;
   align-items: stretch;
@@ -3772,6 +3779,7 @@ code {
   display: inline-block;
   vertical-align: text-bottom;
   flex-shrink: 0;
+  pointer-events: none;
 }
 .bb-toolbar__btn svg.w-3,
 .bb-toolbar__btn svg.h-3 {
@@ -3978,6 +3986,7 @@ code {
   height: 28px;
   flex-shrink: 0;
   position: relative;
+  z-index: 2;
   background-color: #2e2e2e;
   background-image:
     repeating-linear-gradient(
@@ -4037,11 +4046,12 @@ code {
   cursor: pointer;
   flex-shrink: 0;
 }
-.bb-viz__toolbar-btn:hover:not(:disabled) { filter: brightness(1.3); color: #eee; }
+.bb-viz__toolbar-btn:hover:not(:disabled):not([aria-disabled="true"]) { filter: brightness(1.3); color: #eee; }
 .bb-viz__toolbar-btn svg {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  pointer-events: none;
 }
 .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn {
   background: #2a2a2a;
@@ -4052,8 +4062,8 @@ code {
   padding: 0;
   font-size: 10px;
 }
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not(:disabled),
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not(:disabled) {
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not([aria-disabled="true"]),
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not([aria-disabled="true"]) {
   color: var(--bb-accent, #c8a227);
   background:
     radial-gradient(ellipse at 50% 0%, rgba(200,162,39,0.16) 0%, transparent 70%),
@@ -4067,7 +4077,8 @@ code {
   width: 14px;
   height: 14px;
 }
-.bb-viz__toolbar-btn:disabled {
+.bb-viz__toolbar-btn:disabled,
+.bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.55;
   cursor: default;
   color: #565656;
@@ -4075,7 +4086,12 @@ code {
   border-color: #303030;
   box-shadow: none;
 }
-.bb-viz__toolbar-btn:disabled svg {
+.bb-viz__toolbar-btn[aria-disabled="true"]:hover {
+  filter: none;
+  color: #565656;
+}
+.bb-viz__toolbar-btn:disabled svg,
+.bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 .bb-viz__toolbar-btn--performance { margin-left: auto; }
@@ -4322,17 +4338,26 @@ code {
   overflow: hidden;
   box-sizing: border-box;
   outline: none;
+  -webkit-app-region: no-drag;
 }
 .bb-viz--fullscreen .bb-viz__toolbar {
   opacity: 0.92;
   flex-shrink: 0;
   position: absolute;
-  top: 12px;
+  /* Clear the 32px custom title bar / traffic-light strip so drag + OS chrome
+     cannot swallow exit / fullscreen / transport hits. */
+  top: 40px;
   left: 12px;
   right: 12px;
   z-index: 3;
   pointer-events: auto;
   transition: opacity 0.25s ease;
+  -webkit-app-region: no-drag;
+}
+.bb-viz--fullscreen .bb-viz__toolbar-btn,
+.bb-viz--fullscreen .bb-cp__btn,
+.bb-viz--fullscreen .bb-viz__btn {
+  -webkit-app-region: no-drag;
 }
 .bb-viz--fullscreen.bb-viz--chrome-hidden {
   cursor: none;
@@ -4340,21 +4365,31 @@ code {
 .bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar {
   /* Opacity-only — keep hit-testing so hover/click work without leave/re-enter */
   opacity: 0;
+  cursor: default;
 }
-.bb-viz--fullscreen .bb-cp__btn,
-.bb-viz--fullscreen .bb-viz__btn {
-  transition: opacity 0.25s ease;
+.bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar-btn {
+  cursor: pointer;
+}
+.bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar-btn:disabled,
+.bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar-btn[aria-disabled="true"] {
+  cursor: default;
 }
 .bb-viz--fullscreen.bb-viz--chrome-hidden .bb-cp__btn,
 .bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__btn {
   /* Opacity-only — keep hit-testing so hover/click work without leave/re-enter */
   opacity: 0;
+  cursor: pointer;
+}
+.bb-viz--fullscreen .bb-cp__btn,
+.bb-viz--fullscreen .bb-viz__btn {
+  transition: opacity 0.25s ease;
 }
 .bb-viz--fullscreen .bb-viz__toolbar-btn svg {
   pointer-events: none;
 }
 /* Keep disabled toolbar buttons visible in fullscreen */
-.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled { opacity: 0.45; }
+.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled,
+.bb-viz--fullscreen .bb-viz__toolbar-btn[aria-disabled="true"] { opacity: 0.45; }
 .bb-viz--fullscreen .bb-viz__channels {
   flex: 1;
   min-height: 0;
@@ -4551,19 +4586,21 @@ code {
 [data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn svg {
   stroke-width: 2;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled) {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled):not([aria-disabled="true"]) {
   background: #f4f4f4;
   border-color: #888;
   color: #000;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.58;
   color: #9a9a9a;
   background: #eeeeee;
   border-color: #d2d2d2;
   box-shadow: none;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 [data-theme="light"] .bb-viz .bb-cp__btn {
@@ -4728,6 +4765,7 @@ code {
 .bb-cp__position { font-size: 11px; color: #666; font-family: 'DSEG7-Classic', 'Share Tech Mono', 'Consolas', monospace; letter-spacing: 0.05em; }
 .bb-cp__ctrl-row { display: flex; align-items: center; gap: 4px; margin-top: 2px; }
 .bb-cp__btn {
+  position: relative;
   width: 18px; height: 18px; padding: 0; cursor: pointer;
   border: 1px solid;
   border-color: #5a5a5a #242424 #1a1a1a #5a5a5a;
@@ -4739,6 +4777,13 @@ code {
     0 1px 3px rgba(0,0,0,0.50),
     inset 0 1px 0 rgba(255,255,255,0.10);
   transition: filter 0.08s, color 0.08s;
+}
+/* Electron/macOS native title tooltips are flaky unless hover hits the
+   titled element itself — cover the face so tooltips register reliably. */
+.bb-cp__btn[title]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
 }
 .bb-cp--full .bb-cp__btn { width: 22px; height: 22px; font-size: 11px; }
 .bb-cp--full .bb-cp__vol-wrap { min-width: 90px; }
@@ -4866,6 +4911,7 @@ code {
   flex-shrink: 0;
 }
 .bb-chat-title svg { margin-right: 0.25rem; }
+.bb-chat-settings-btn svg { pointer-events: none; }
 .bb-chat-settings-btn { background: none; border: none; color: var(--text-muted, #888); cursor: pointer; font-size: 14px; padding: 2px 4px; border-radius: 3px; line-height: 1; transition: color 0.1s, background 0.1s; }
 .bb-chat-settings-btn:hover { color: var(--text-color, #d4d4d4); background: var(--button-hover-bg, #2a2d2e); }
 .bb-chat-subtitle { font-size: 11px; color: var(--text-muted, #888); margin-top: 2px; }
@@ -5205,6 +5251,10 @@ code {
   cursor: pointer;
   font-size: 10px;
   flex-shrink: 0;
+}
+
+.bb-channel-mixer__toolbar-btn svg {
+  pointer-events: none;
 }
 
 .bb-channel-mixer__toolbar-btn:hover { filter: brightness(1.3); color: #eee; }
@@ -5937,9 +5987,10 @@ code {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  pointer-events: none;
 }
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not(:disabled),
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not(:disabled) {
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not([aria-disabled="true"]),
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not([aria-disabled="true"]) {
   color: var(--bb-accent, #c8a227);
   background:
     radial-gradient(ellipse at 50% 0%, rgba(200,162,39,0.16) 0%, transparent 70%),
@@ -5949,7 +6000,8 @@ code {
     0 0 5px rgba(200,162,39,0.16),
     inset 0 1px 0 rgba(255,255,255,0.12);
 }
-.bb-viz__toolbar-btn:disabled {
+.bb-viz__toolbar-btn:disabled,
+.bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.55;
   cursor: default;
   color: #565656;
@@ -5957,7 +6009,12 @@ code {
   border-color: #303030;
   box-shadow: none;
 }
-.bb-viz__toolbar-btn:disabled svg {
+.bb-viz__toolbar-btn[aria-disabled="true"]:hover {
+  filter: none;
+  color: #565656;
+}
+.bb-viz__toolbar-btn:disabled svg,
+.bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 .bb-viz__toolbar-btn--performance { margin-left: auto; }
@@ -6179,17 +6236,26 @@ code {
   overflow: hidden;
   box-sizing: border-box;
   outline: none;
+  -webkit-app-region: no-drag;
 }
 .bb-viz--fullscreen .bb-viz__toolbar {
   opacity: 0.92;
   flex-shrink: 0;
   position: absolute;
-  top: 12px;
+  /* Clear the 32px custom title bar / traffic-light strip so drag + OS chrome
+     cannot swallow exit / fullscreen / transport hits. */
+  top: 40px;
   left: 12px;
   right: 12px;
   z-index: 3;
   pointer-events: auto;
   transition: opacity 0.25s ease;
+  -webkit-app-region: no-drag;
+}
+.bb-viz--fullscreen .bb-viz__toolbar-btn,
+.bb-viz--fullscreen .bb-cp__btn,
+.bb-viz--fullscreen .bb-viz__btn {
+  -webkit-app-region: no-drag;
 }
 .bb-viz--fullscreen.bb-viz--chrome-hidden {
   cursor: none;
@@ -6197,21 +6263,31 @@ code {
 .bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar {
   /* Opacity-only — keep hit-testing so hover/click work without leave/re-enter */
   opacity: 0;
+  cursor: default;
 }
-.bb-viz--fullscreen .bb-cp__btn,
-.bb-viz--fullscreen .bb-viz__btn {
-  transition: opacity 0.25s ease;
+.bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar-btn {
+  cursor: pointer;
+}
+.bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar-btn:disabled,
+.bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__toolbar-btn[aria-disabled="true"] {
+  cursor: default;
 }
 .bb-viz--fullscreen.bb-viz--chrome-hidden .bb-cp__btn,
 .bb-viz--fullscreen.bb-viz--chrome-hidden .bb-viz__btn {
   /* Opacity-only — keep hit-testing so hover/click work without leave/re-enter */
   opacity: 0;
+  cursor: pointer;
+}
+.bb-viz--fullscreen .bb-cp__btn,
+.bb-viz--fullscreen .bb-viz__btn {
+  transition: opacity 0.25s ease;
 }
 .bb-viz--fullscreen .bb-viz__toolbar-btn svg {
   pointer-events: none;
 }
 /* Keep disabled toolbar buttons visible in fullscreen */
-.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled { opacity: 0.45; }
+.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled,
+.bb-viz--fullscreen .bb-viz__toolbar-btn[aria-disabled="true"] { opacity: 0.45; }
 .bb-viz--fullscreen .bb-viz__channels {
   flex: 1;
   min-height: 0;
@@ -6399,19 +6475,21 @@ code {
 [data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn svg {
   stroke-width: 2;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled) {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled):not([aria-disabled="true"]) {
   background: #f4f4f4;
   border-color: #888;
   color: #000;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.58;
   color: #9a9a9a;
   background: #eeeeee;
   border-color: #d2d2d2;
   box-shadow: none;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 [data-theme="light"] .bb-viz .bb-cp__btn {
@@ -6576,6 +6654,7 @@ code {
 .bb-cp__position { font-size: 11px; color: #666; font-family: 'DSEG7-Classic', 'Share Tech Mono', 'Consolas', monospace; letter-spacing: 0.05em; }
 .bb-cp__ctrl-row { display: flex; align-items: center; gap: 4px; margin-top: 2px; }
 .bb-cp__btn {
+  position: relative;
   width: 18px; height: 18px; padding: 0; cursor: pointer;
   border: 1px solid;
   border-color: #5a5a5a #242424 #1a1a1a #5a5a5a;
@@ -6587,6 +6666,13 @@ code {
     0 1px 3px rgba(0,0,0,0.50),
     inset 0 1px 0 rgba(255,255,255,0.10);
   transition: filter 0.08s, color 0.08s;
+}
+/* Electron/macOS native title tooltips are flaky unless hover hits the
+   titled element itself — cover the face so tooltips register reliably. */
+.bb-cp__btn[title]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
 }
 .bb-cp--full .bb-cp__btn { width: 22px; height: 22px; font-size: 11px; }
 .bb-cp--full .bb-cp__vol-wrap { min-width: 90px; }
@@ -6714,6 +6800,7 @@ code {
   flex-shrink: 0;
 }
 .bb-chat-title svg { margin-right: 0.25rem; }
+.bb-chat-settings-btn svg { pointer-events: none; }
 .bb-chat-settings-btn { background: none; border: none; color: var(--text-muted, #888); cursor: pointer; font-size: 14px; padding: 2px 4px; border-radius: 3px; line-height: 1; transition: color 0.1s, background 0.1s; }
 .bb-chat-settings-btn:hover { color: var(--text-color, #d4d4d4); background: var(--button-hover-bg, #2a2d2e); }
 .bb-chat-subtitle { font-size: 11px; color: var(--text-muted, #888); margin-top: 2px; }

--- a/apps/desktop/tests/e2e/desktop-integration.spec.ts
+++ b/apps/desktop/tests/e2e/desktop-integration.spec.ts
@@ -553,21 +553,21 @@ test('view menu reflects open visualizer tab on startup', async () => {
   await expect(page.locator('#bb-viz-clear-solo')).toBeVisible();
   await page.locator('#bb-viz-mute-1').click();
   await expect(page.locator('#bb-viz-mute-1')).toHaveClass(/bb-cp__btn--active/);
-  await expect(page.locator('#bb-viz-unmute-all')).toBeEnabled();
-  await page.locator('#bb-viz-unmute-all svg').click();
+  await expect(page.locator('#bb-viz-unmute-all')).not.toHaveAttribute('aria-disabled', 'true');
+  await page.locator('#bb-viz-unmute-all').click();
   await expect(page.locator('#bb-viz-mute-1')).not.toHaveClass(/bb-cp__btn--active/);
-  await expect(page.locator('#bb-viz-unmute-all')).toBeDisabled();
+  await expect(page.locator('#bb-viz-unmute-all')).toHaveAttribute('aria-disabled', 'true');
 
   await page.locator('#bb-viz-solo-2').click();
   await expect(page.locator('#bb-viz-solo-2')).toHaveClass(/bb-cp__btn--active/);
-  await expect(page.locator('#bb-viz-clear-solo')).toBeEnabled();
-  await page.locator('#bb-viz-clear-solo svg').click();
+  await expect(page.locator('#bb-viz-clear-solo')).not.toHaveAttribute('aria-disabled', 'true');
+  await page.locator('#bb-viz-clear-solo').click();
   await expect(page.locator('#bb-viz-solo-2')).not.toHaveClass(/bb-cp__btn--active/);
-  await expect(page.locator('#bb-viz-clear-solo')).toBeDisabled();
+  await expect(page.locator('#bb-viz-clear-solo')).toHaveAttribute('aria-disabled', 'true');
 
-  await page.locator('#bb-viz-fullscreen svg').click();
+  await page.locator('#bb-viz-fullscreen').click();
   await expect(page.locator('#bb-viz-root')).toHaveClass(/bb-viz--fullscreen/);
-  await page.locator('#bb-viz-exit svg').click();
+  await page.locator('#bb-viz-exit').click();
   await expect(page.locator('#bb-viz-root')).not.toHaveClass(/bb-viz--fullscreen/);
 
   await electronApp.close();
@@ -596,14 +596,14 @@ test('channel mixer renders desktop React UI and toggles channel state', async (
   await page.locator('#bb-channel-mixer-mute-1').click();
   await expect(page.locator('#bb-channel-mixer-mute-1')).toHaveClass(/bb-cp__btn--active/);
   await expect(page.locator('#bb-channel-mixer-unmute-all')).not.toHaveAttribute('aria-disabled', 'true');
-  await page.locator('#bb-channel-mixer-unmute-all svg').click();
+  await page.locator('#bb-channel-mixer-unmute-all').click();
   await expect(page.locator('#bb-channel-mixer-mute-1')).not.toHaveClass(/bb-cp__btn--active/);
   await expect(page.locator('#bb-channel-mixer-unmute-all')).toHaveAttribute('aria-disabled', 'true');
 
   await page.locator('#bb-channel-mixer-solo-2').click();
   await expect(page.locator('#bb-channel-mixer-solo-2')).toHaveClass(/bb-cp__btn--active/);
   await expect(page.locator('#bb-channel-mixer-clear-solo')).not.toHaveAttribute('aria-disabled', 'true');
-  await page.locator('#bb-channel-mixer-clear-solo svg').click();
+  await page.locator('#bb-channel-mixer-clear-solo').click();
   await expect(page.locator('#bb-channel-mixer-solo-2')).not.toHaveClass(/bb-cp__btn--active/);
   await expect(page.locator('#bb-channel-mixer-clear-solo')).toHaveAttribute('aria-disabled', 'true');
 
@@ -615,7 +615,7 @@ test('channel mixer renders desktop React UI and toggles channel state', async (
   await expect(page.locator('[data-lcd="vol"]')).toContainText('25%');
   await expect.poll(() => page.evaluate(() => localStorage.getItem('beatbax:transport.masterVolume'))).toBe('25');
 
-  await page.locator('#bb-channel-mixer-dock-mode svg').click();
+  await page.locator('#bb-channel-mixer-dock-mode').click();
   await expect(page.locator('#bb-channel-mixer')).toHaveClass(/bb-channel-mixer--inline/);
 
   await page.evaluate(() => {

--- a/apps/web-ui/src/main.ts
+++ b/apps/web-ui/src/main.ts
@@ -1518,6 +1518,7 @@ toolbar = new Toolbar({
   onUndo:      () => editor.editor?.trigger('toolbar', 'undo', null),
   onRedo:      () => editor.editor?.trigger('toolbar', 'redo', null),
   onToggleTheme: () => themeManager.toggle(),
+  onOpenSettings: () => settingsModal.open(),
   onToggleWrap:  (wrap: boolean) => {
     settingWordWrap.set(wrap);
     editor.editor?.updateOptions({ wordWrap: wrap ? 'on' : 'off' });

--- a/apps/web-ui/src/panels/song-visualizer.ts
+++ b/apps/web-ui/src/panels/song-visualizer.ts
@@ -507,11 +507,8 @@ export class SongVisualizer {
     unmuteBtn.setAttribute('aria-label', 'Unmute all channels');
     setAriaDisabled(unmuteBtn, !Object.values(channelStates.get()).some(s => s.muted));
     unmuteBtn.innerHTML = icon('speaker-wave');
-    unmuteBtn.addEventListener('pointerdown', (event) => {
-      if (event.button !== 0 || unmuteBtn.dataset.ariaDisabled) return;
-      event.preventDefault();
-      event.stopPropagation();
-      unmuteAll();
+    bindToolbarPrimaryAction(unmuteBtn, unmuteAll, {
+      isEnabled: () => !unmuteBtn.dataset.ariaDisabled,
     });
 
     const clearSoloBtn = document.createElement('button');
@@ -522,11 +519,8 @@ export class SongVisualizer {
     clearSoloBtn.setAttribute('aria-label', 'Clear solo on all channels');
     setAriaDisabled(clearSoloBtn, !Object.values(channelStates.get()).some(s => s.soloed));
     clearSoloBtn.innerHTML = icon('eye');
-    clearSoloBtn.addEventListener('pointerdown', (event) => {
-      if (event.button !== 0 || clearSoloBtn.dataset.ariaDisabled) return;
-      event.preventDefault();
-      event.stopPropagation();
-      clearAllSolo();
+    bindToolbarPrimaryAction(clearSoloBtn, clearAllSolo, {
+      isEnabled: () => !clearSoloBtn.dataset.ariaDisabled,
     });
 
     const performanceTransport = document.createElement('div');
@@ -564,10 +558,7 @@ export class SongVisualizer {
     performanceBtn.className = 'bb-viz__toolbar-btn bb-viz__toolbar-btn--performance';
     performanceBtn.id = 'bb-viz-fullscreen';
     this.updatePerformanceButton(performanceBtn);
-    performanceBtn.addEventListener('pointerdown', (event) => {
-      if (event.button !== 0) return;
-      event.preventDefault();
-      event.stopPropagation();
+    bindToolbarPrimaryAction(performanceBtn, () => {
       if (!this.performanceMode) {
         this.performanceMode = true;
         this.render();
@@ -593,10 +584,7 @@ export class SongVisualizer {
     exitPerformanceBtn.title = 'Exit performance mode';
     exitPerformanceBtn.setAttribute('aria-label', 'Exit performance mode');
     exitPerformanceBtn.innerHTML = icon('x-mark');
-    exitPerformanceBtn.addEventListener('pointerdown', (event) => {
-      if (event.button !== 0) return;
-      event.preventDefault();
-      event.stopPropagation();
+    bindToolbarPrimaryAction(exitPerformanceBtn, () => {
       this.performanceMode = false;
       const finishExit = () => this.render();
       if (document.fullscreenElement) {
@@ -1229,4 +1217,30 @@ function setAriaDisabled(btn: HTMLButtonElement, disabled: boolean): void {
     btn.removeAttribute('aria-disabled');
     delete btn.dataset.ariaDisabled;
   }
+}
+
+/**
+ * Run toolbar actions on pointerdown (avoids lost clicks when the button re-renders)
+ * and on keyboard-initiated clicks only (Enter/Space fire click with detail === 0,
+ * without a preceding pointer event).
+ */
+function bindToolbarPrimaryAction(
+  button: HTMLButtonElement,
+  action: () => void,
+  opts?: { isEnabled?: () => boolean },
+): void {
+  const run = (event: Event) => {
+    if (opts?.isEnabled && !opts.isEnabled()) return;
+    event.preventDefault();
+    event.stopPropagation();
+    action();
+  };
+  button.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0) return;
+    run(event);
+  });
+  button.addEventListener('click', (event) => {
+    if (event.detail !== 0) return;
+    run(event);
+  });
 }

--- a/apps/web-ui/src/panels/song-visualizer.ts
+++ b/apps/web-ui/src/panels/song-visualizer.ts
@@ -504,18 +504,30 @@ export class SongVisualizer {
     unmuteBtn.className = 'bb-viz__toolbar-btn';
     unmuteBtn.id = 'bb-viz-unmute-all';
     unmuteBtn.title = 'Unmute all channels';
-    unmuteBtn.disabled = !Object.values(channelStates.get()).some(s => s.muted);
+    unmuteBtn.setAttribute('aria-label', 'Unmute all channels');
+    setAriaDisabled(unmuteBtn, !Object.values(channelStates.get()).some(s => s.muted));
     unmuteBtn.innerHTML = icon('speaker-wave');
-    unmuteBtn.addEventListener('click', () => unmuteAll());
+    unmuteBtn.addEventListener('pointerdown', (event) => {
+      if (event.button !== 0 || unmuteBtn.dataset.ariaDisabled) return;
+      event.preventDefault();
+      event.stopPropagation();
+      unmuteAll();
+    });
 
     const clearSoloBtn = document.createElement('button');
     clearSoloBtn.type = 'button';
     clearSoloBtn.className = 'bb-viz__toolbar-btn';
     clearSoloBtn.id = 'bb-viz-clear-solo';
     clearSoloBtn.title = 'Clear solo';
-    clearSoloBtn.disabled = !Object.values(channelStates.get()).some(s => s.soloed);
+    clearSoloBtn.setAttribute('aria-label', 'Clear solo on all channels');
+    setAriaDisabled(clearSoloBtn, !Object.values(channelStates.get()).some(s => s.soloed));
     clearSoloBtn.innerHTML = icon('eye');
-    clearSoloBtn.addEventListener('click', () => clearAllSolo());
+    clearSoloBtn.addEventListener('pointerdown', (event) => {
+      if (event.button !== 0 || clearSoloBtn.dataset.ariaDisabled) return;
+      event.preventDefault();
+      event.stopPropagation();
+      clearAllSolo();
+    });
 
     const performanceTransport = document.createElement('div');
     performanceTransport.className = 'bb-viz__performance-transport';
@@ -552,7 +564,10 @@ export class SongVisualizer {
     performanceBtn.className = 'bb-viz__toolbar-btn bb-viz__toolbar-btn--performance';
     performanceBtn.id = 'bb-viz-fullscreen';
     this.updatePerformanceButton(performanceBtn);
-    performanceBtn.addEventListener('click', () => {
+    performanceBtn.addEventListener('pointerdown', (event) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
       if (!this.performanceMode) {
         this.performanceMode = true;
         this.render();
@@ -578,7 +593,10 @@ export class SongVisualizer {
     exitPerformanceBtn.title = 'Exit performance mode';
     exitPerformanceBtn.setAttribute('aria-label', 'Exit performance mode');
     exitPerformanceBtn.innerHTML = icon('x-mark');
-    exitPerformanceBtn.addEventListener('click', () => {
+    exitPerformanceBtn.addEventListener('pointerdown', (event) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
       this.performanceMode = false;
       const finishExit = () => this.render();
       if (document.fullscreenElement) {
@@ -822,9 +840,9 @@ export class SongVisualizer {
         const anyMuted = Object.values(states).some(s => s.muted);
         const anySoloed = Object.values(states).some(s => s.soloed);
         const unmuteAllBtn = document.getElementById('bb-viz-unmute-all') as HTMLButtonElement | null;
-        if (unmuteAllBtn) unmuteAllBtn.disabled = !anyMuted;
+        if (unmuteAllBtn) setAriaDisabled(unmuteAllBtn, !anyMuted);
         const clearSoloAllBtn = document.getElementById('bb-viz-clear-solo') as HTMLButtonElement | null;
-        if (clearSoloAllBtn) clearSoloAllBtn.disabled = !anySoloed;
+        if (clearSoloAllBtn) setAriaDisabled(clearSoloAllBtn, !anySoloed);
         for (const [id, info] of Object.entries(states)) {
           const channelId = Number(id);
           const muteBtn = document.getElementById(`bb-viz-mute-${channelId}`) as HTMLButtonElement | null;
@@ -1037,13 +1055,15 @@ export class SongVisualizer {
   private applyMuteStyle(btn: HTMLButtonElement, muted: boolean): void {
     btn.textContent = 'M';
     btn.title = muted ? 'Unmute channel' : 'Mute channel';
+    btn.setAttribute('aria-label', btn.title);
     btn.setAttribute('aria-pressed', String(muted));
     btn.classList.toggle('bb-cp__btn--active', muted);
   }
 
   private applySoloStyle(btn: HTMLButtonElement, soloed: boolean): void {
     btn.textContent = 'S';
-    btn.title = soloed ? 'Remove solo' : 'Solo this channel';
+    btn.title = soloed ? 'Unsolo channel' : 'Solo channel';
+    btn.setAttribute('aria-label', btn.title);
     btn.setAttribute('aria-pressed', String(soloed));
     btn.classList.toggle('bb-cp__btn--active', soloed);
   }
@@ -1198,5 +1218,15 @@ export class SongVisualizer {
     document.body.classList.remove('bb-viz-wide-mode');
     const rightPane = document.getElementById('right-pane');
     if (rightPane) rightPane.style.minWidth = '';
+  }
+}
+
+function setAriaDisabled(btn: HTMLButtonElement, disabled: boolean): void {
+  if (disabled) {
+    btn.setAttribute('aria-disabled', 'true');
+    btn.dataset.ariaDisabled = 'true';
+  } else {
+    btn.removeAttribute('aria-disabled');
+    delete btn.dataset.ariaDisabled;
   }
 }

--- a/apps/web-ui/src/styles.css
+++ b/apps/web-ui/src/styles.css
@@ -3269,6 +3269,7 @@
   display: inline-block;
   vertical-align: text-bottom;
   flex-shrink: 0;
+  pointer-events: none;
 }
 .bb-toolbar__btn svg.w-3,
 .bb-toolbar__btn svg.h-3 {
@@ -3475,6 +3476,7 @@
   height: 28px;
   flex-shrink: 0;
   position: relative;
+  z-index: 2;
   background-color: #2e2e2e;
   background-image:
     repeating-linear-gradient(
@@ -3534,11 +3536,12 @@
   cursor: pointer;
   flex-shrink: 0;
 }
-.bb-viz__toolbar-btn:hover:not(:disabled) { filter: brightness(1.3); color: #eee; }
+.bb-viz__toolbar-btn:hover:not(:disabled):not([aria-disabled="true"]) { filter: brightness(1.3); color: #eee; }
 .bb-viz__toolbar-btn svg {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  pointer-events: none;
 }
 .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn {
   background: #2a2a2a;
@@ -3549,8 +3552,8 @@
   padding: 0;
   font-size: 10px;
 }
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not(:disabled),
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not(:disabled) {
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not([aria-disabled="true"]),
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not([aria-disabled="true"]) {
   color: var(--bb-accent, #c8a227);
   background:
     radial-gradient(ellipse at 50% 0%, rgba(200,162,39,0.16) 0%, transparent 70%),
@@ -3564,7 +3567,8 @@
   width: 14px;
   height: 14px;
 }
-.bb-viz__toolbar-btn:disabled {
+.bb-viz__toolbar-btn:disabled,
+.bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.55;
   cursor: default;
   color: #565656;
@@ -3572,7 +3576,12 @@
   border-color: #303030;
   box-shadow: none;
 }
-.bb-viz__toolbar-btn:disabled svg {
+.bb-viz__toolbar-btn[aria-disabled="true"]:hover {
+  filter: none;
+  color: #565656;
+}
+.bb-viz__toolbar-btn:disabled svg,
+.bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 .bb-viz__toolbar-btn--performance { margin-left: auto; }
@@ -3834,7 +3843,8 @@
   pointer-events: none;
 }
 /* Keep disabled toolbar buttons visible in fullscreen */
-.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled { opacity: 0.45; }
+.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled,
+.bb-viz--fullscreen .bb-viz__toolbar-btn[aria-disabled="true"] { opacity: 0.45; }
 .bb-viz--fullscreen .bb-viz__channels {
   flex: 1;
   min-height: 0;
@@ -4031,19 +4041,21 @@
 [data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn svg {
   stroke-width: 2;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled) {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled):not([aria-disabled="true"]) {
   background: #f4f4f4;
   border-color: #888;
   color: #000;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.58;
   color: #9a9a9a;
   background: #eeeeee;
   border-color: #d2d2d2;
   box-shadow: none;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 [data-theme="light"] .bb-viz .bb-cp__btn {
@@ -4208,6 +4220,7 @@
 .bb-cp__position { font-size: 11px; color: #666; font-family: 'DSEG7-Classic', 'Share Tech Mono', 'Consolas', monospace; letter-spacing: 0.05em; }
 .bb-cp__ctrl-row { display: flex; align-items: center; gap: 4px; margin-top: 2px; }
 .bb-cp__btn {
+  position: relative;
   width: 18px; height: 18px; padding: 0; cursor: pointer;
   border: 1px solid;
   border-color: #5a5a5a #242424 #1a1a1a #5a5a5a;
@@ -4219,6 +4232,13 @@
     0 1px 3px rgba(0,0,0,0.50),
     inset 0 1px 0 rgba(255,255,255,0.10);
   transition: filter 0.08s, color 0.08s;
+}
+/* Electron/macOS native title tooltips are flaky unless hover hits the
+   titled element itself — cover the face so tooltips register reliably. */
+.bb-cp__btn[title]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
 }
 .bb-cp--full .bb-cp__btn { width: 22px; height: 22px; font-size: 11px; }
 .bb-cp--full .bb-cp__vol-wrap { min-width: 90px; }
@@ -4346,6 +4366,7 @@
   flex-shrink: 0;
 }
 .bb-chat-title svg { margin-right: 0.25rem; }
+.bb-chat-settings-btn svg { pointer-events: none; }
 .bb-chat-settings-btn { background: none; border: none; color: var(--text-muted, #888); cursor: pointer; font-size: 14px; padding: 2px 4px; border-radius: 3px; line-height: 1; transition: color 0.1s, background 0.1s; }
 .bb-chat-settings-btn:hover { color: var(--text-color, #d4d4d4); background: var(--button-hover-bg, #2a2d2e); }
 .bb-chat-subtitle { font-size: 11px; color: var(--text-muted, #888); margin-top: 2px; }
@@ -4645,6 +4666,10 @@
   cursor: pointer;
   font-size: 10px;
   flex-shrink: 0;
+}
+
+.bb-channel-mixer__toolbar-btn svg {
+  pointer-events: none;
 }
 
 .bb-channel-mixer__toolbar-btn:hover { filter: brightness(1.3); color: #eee; }
@@ -5377,9 +5402,10 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  pointer-events: none;
 }
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not(:disabled),
-.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not(:disabled) {
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-unmute-all:not([aria-disabled="true"]),
+.bb-viz:not(.bb-viz--fullscreen) #bb-viz-clear-solo:not([aria-disabled="true"]) {
   color: var(--bb-accent, #c8a227);
   background:
     radial-gradient(ellipse at 50% 0%, rgba(200,162,39,0.16) 0%, transparent 70%),
@@ -5389,7 +5415,8 @@
     0 0 5px rgba(200,162,39,0.16),
     inset 0 1px 0 rgba(255,255,255,0.12);
 }
-.bb-viz__toolbar-btn:disabled {
+.bb-viz__toolbar-btn:disabled,
+.bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.55;
   cursor: default;
   color: #565656;
@@ -5397,7 +5424,12 @@
   border-color: #303030;
   box-shadow: none;
 }
-.bb-viz__toolbar-btn:disabled svg {
+.bb-viz__toolbar-btn[aria-disabled="true"]:hover {
+  filter: none;
+  color: #565656;
+}
+.bb-viz__toolbar-btn:disabled svg,
+.bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 .bb-viz__toolbar-btn--performance { margin-left: auto; }
@@ -5651,7 +5683,8 @@
   pointer-events: none;
 }
 /* Keep disabled toolbar buttons visible in fullscreen */
-.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled { opacity: 0.45; }
+.bb-viz--fullscreen .bb-viz__toolbar-btn:disabled,
+.bb-viz--fullscreen .bb-viz__toolbar-btn[aria-disabled="true"] { opacity: 0.45; }
 .bb-viz--fullscreen .bb-viz__channels {
   flex: 1;
   min-height: 0;
@@ -5839,19 +5872,21 @@
 [data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn svg {
   stroke-width: 2;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled) {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:hover:not(:disabled):not([aria-disabled="true"]) {
   background: #f4f4f4;
   border-color: #888;
   color: #000;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] {
   opacity: 0.58;
   color: #9a9a9a;
   background: #eeeeee;
   border-color: #d2d2d2;
   box-shadow: none;
 }
-[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg {
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn:disabled svg,
+[data-theme="light"] .bb-viz:not(.bb-viz--fullscreen) .bb-viz__toolbar-btn[aria-disabled="true"] svg {
   stroke-width: 1.75;
 }
 [data-theme="light"] .bb-viz .bb-cp__btn {
@@ -6016,6 +6051,7 @@
 .bb-cp__position { font-size: 11px; color: #666; font-family: 'DSEG7-Classic', 'Share Tech Mono', 'Consolas', monospace; letter-spacing: 0.05em; }
 .bb-cp__ctrl-row { display: flex; align-items: center; gap: 4px; margin-top: 2px; }
 .bb-cp__btn {
+  position: relative;
   width: 18px; height: 18px; padding: 0; cursor: pointer;
   border: 1px solid;
   border-color: #5a5a5a #242424 #1a1a1a #5a5a5a;
@@ -6027,6 +6063,13 @@
     0 1px 3px rgba(0,0,0,0.50),
     inset 0 1px 0 rgba(255,255,255,0.10);
   transition: filter 0.08s, color 0.08s;
+}
+/* Electron/macOS native title tooltips are flaky unless hover hits the
+   titled element itself — cover the face so tooltips register reliably. */
+.bb-cp__btn[title]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
 }
 .bb-cp--full .bb-cp__btn { width: 22px; height: 22px; font-size: 11px; }
 .bb-cp--full .bb-cp__vol-wrap { min-width: 90px; }
@@ -6154,6 +6197,7 @@
   flex-shrink: 0;
 }
 .bb-chat-title svg { margin-right: 0.25rem; }
+.bb-chat-settings-btn svg { pointer-events: none; }
 .bb-chat-settings-btn { background: none; border: none; color: var(--text-muted, #888); cursor: pointer; font-size: 14px; padding: 2px 4px; border-radius: 3px; line-height: 1; transition: color 0.1s, background 0.1s; }
 .bb-chat-settings-btn:hover { color: var(--text-color, #d4d4d4); background: var(--button-hover-bg, #2a2d2e); }
 .bb-chat-subtitle { font-size: 11px; color: var(--text-muted, #888); margin-top: 2px; }

--- a/apps/web-ui/src/ui/toolbar.ts
+++ b/apps/web-ui/src/ui/toolbar.ts
@@ -64,6 +64,8 @@ export interface ToolbarOptions {
   //onFormat?: () => void;
   /** Toggle dark/light theme. */
   onToggleTheme?: () => void;
+  /** Open the Settings panel. */
+  onOpenSettings?: () => void;
   /** Toggle word-wrap. Receives the new enabled state. */
   onToggleWrap?: (enabled: boolean) => void;
   /** Fold or unfold all comments. */
@@ -154,6 +156,11 @@ export class Toolbar {
         <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-theme" title="Switch to light theme">
           ${icon('sun', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Light</span>
         </button>
+        ${caps.settingsPanel ? `
+        <button class="bb-toolbar__btn bb-toolbar__btn--icon" id="tb-settings" title="Settings (${toolbarShortcut('tools.openSettings')})" aria-label="Settings (${toolbarShortcut('tools.openSettings')})">
+          ${icon('cog-6-tooth', 'w-4 h-4 inline-block align-text-bottom')} <span class="bb-toolbar__btn-label">Settings</span>
+        </button>
+        ` : ''}
       </div>
     `;
 
@@ -219,7 +226,7 @@ export class Toolbar {
   private attachEvents(): void {
         const { eventBus, onLoad, onExport, onVerify,
           onNew, onSave, onUndo, onRedo, /*onFormat,*/
-          onToggleTheme, onToggleWrap, onToggleFoldComments,
+          onToggleTheme, onOpenSettings, onToggleWrap, onToggleFoldComments,
           onOpenFileReadStart, onOpenFileReadEnd,
           onBeforeOpenFile, onBeforeExampleLoad } = this.options;
         const caps = getCurrentCapabilities();
@@ -409,6 +416,12 @@ export class Toolbar {
     this._themeToggleBtn = this.el.querySelector<HTMLButtonElement>('#tb-theme') ?? undefined;
     if (this._themeToggleBtn) {
       this._themeToggleBtn.addEventListener('click', () => onToggleTheme?.());
+    }
+
+    // Settings
+    const settingsBtn = this.el.querySelector<HTMLButtonElement>('#tb-settings');
+    if (settingsBtn) {
+      settingsBtn.addEventListener('click', () => onOpenSettings?.());
     }
 
     // Fold/Unfold comments


### PR DESCRIPTION

<!-- Describe the purpose of this PR and the changes it makes. -->

### Summary

Make Visualizer unmute/clear-solo/performance controls use aria-disabled and pointerdown like the mixer, harden native title tooltips for icon and mute/solo buttons, stop Electron title-bar drag from stealing performance-mode hits, and add a toolbar Settings button next to theme.

### Checklist

- [X] My changes add required tests and they pass.
- [X] I ran `npm test` locally and all tests passed.
- [X] I updated README or docs if required.
- [X] This PR follows repository coding style and guidelines.

### Notes for reviewers

None.